### PR TITLE
Improve history table with previous_groups_id field and counter field

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -252,6 +252,54 @@ function plugin_escalade_install() {
 
    $migration->migrationOneTable('glpi_plugin_escalade_configs');
 
+   if (!$DB->fieldExists('glpi_plugin_escalade_histories', 'previous_groups_id')
+      || !$DB->fieldExists("glpi_plugin_escalade_histories", 'counter')) {
+      if (!$DB->fieldExists('glpi_plugin_escalade_histories', 'previous_groups_id')) {
+         $migration->addField('glpi_plugin_escalade_histories', 'previous_groups_id', 'integer', ['before' => 'groups_id']);
+      }
+      if (!$DB->fieldExists('glpi_plugin_escalade_histories', 'counter')) {
+         $migration->addField('glpi_plugin_escalade_histories', 'counter', 'integer', ['after' => 'groups_id']);
+      }
+      $migration->migrationOneTable('glpi_plugin_escalade_histories');
+
+      $history = new PluginEscaladeHistory();
+      $histories = [];
+      foreach ($history->find() as $data) {
+         $tickets_id = $data['tickets_id'];
+         unset($data['tickets_id']);
+
+         if (!isset($histories[$tickets_id])) {
+            $histories[$tickets_id] = [];
+         }
+
+         $histories[$tickets_id][] = $data;
+      }
+
+      foreach ($histories as $tickets_id => $h) {
+         $counters = [];
+
+         foreach ($h as $k => $details) {
+            if (isset($h[$k+1])) {
+               $first  = $h[$k+1]['groups_id'] < $details['groups_id'] ? $h[$k+1]['groups_id'] : $details['groups_id'];
+               $second = $h[$k+1]['groups_id'] < $details['groups_id'] ? $details['groups_id'] : $h[$k+1]['groups_id'];
+
+               $counters[$first][$second] = isset($counters[$first][$second]) ? $counters[$first][$second] + 1 : 1;
+               $h[$k+1]['previous_groups_id'] = $details['groups_id'];
+               $h[$k+1]['counter'] = $counters[$first][$second];
+            }
+         }
+
+         foreach ($h as $k => $details) {
+            $DB->update(
+               $this->getTable(),
+               ['previous_groups_id' => $details['previous_groups_id'], 'counter' => $details['counter']],
+               ['id' => $details['id']]
+            );
+         }
+      }
+
+   }
+
    return true;
 }
 
@@ -384,6 +432,31 @@ function plugin_escalade_getAddSearchOptions($itemtype) {
                   'jointype'  => 'child',
                   'condition' => ''
                ]
+            ]
+         ];
+
+         $sopt[] = [
+            'id'                 => '1991',
+            'table'              => 'glpi_plugin_escalade_histories',
+            'field'              => 'id',
+            'name'               => __("Number of escalations", "escalade"),
+            'forcegroupby'       => true,
+            'usehaving'          => true,
+            'datatype'           => 'count',
+            'massiveaction'      => false,
+            'joinparams'         => [
+               'jointype'           => 'child'
+            ]
+         ];
+
+         $sopt[] = [
+            'id'                 => '1992',
+            'table'              => 'glpi_plugin_escalade_histories',
+            'field'              => 'counter',
+            'name'               => __("Number of escalations between two groups", "escalade"),
+            'datatype'           => 'integer',
+            'joinparams'         => [
+               'jointype'           => 'child'
             ]
          ];
    }

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -24,6 +24,21 @@ class PluginEscaladeHistory extends CommonDBTM {
       }
    }
 
+   static function getLastHistoryForTicketAndGroup($tickets_id, $groups_id, $previous_groups_id) {
+      $history = new self();
+      $history->getFromDBByRequest(['ORDER'   => 'date_mod DESC',
+                                                 'LIMIT'      => 1,
+                                                 'WHERE' =>
+                                                 [
+                                                   'tickets_id' => $tickets_id,
+                                                   'groups_id' => [$groups_id, $previous_groups_id],
+                                                   'previous_groups_id' => [$groups_id, $previous_groups_id]
+                                                 ]
+                                               ]);
+
+      return $history;
+   }
+
    static function getFullHistory($tickets_id) {
       $history = new self();
       return $history->find("tickets_id = $tickets_id", "date_mod DESC");

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -210,9 +210,31 @@ class PluginEscaladeTicket {
 
       //add line in history table
       $history = new PluginEscaladeHistory();
+
+      $group_ticket       = new Group_Ticket();
+      $group_ticket->getFromDBByRequest(['ORDER'   => 'id DESC',
+                                                 'LIMIT'      => 1,
+                                                 'tickets_id' => $tickets_id,
+                                                 'type'       => 2]);
+
+      $previous_groups_id = 0;
+      $counter            = 0;
+
+      if (count($group_ticket->fields) > 0) {
+         $previous_groups_id = $group_ticket->fields['groups_id'];
+
+         $last_history_groups = PluginEscaladeHistory::getLastHistoryForTicketAndGroup($tickets_id, $groups_id, $previous_groups_id);
+
+         if (count($last_history_groups->fields) > 0) {
+            $counter = $last_history_groups->fields['counter'] + 1;
+         }
+      }
+
       $history->add([
-         'tickets_id' => $tickets_id,
-         'groups_id'  => $groups_id
+         'tickets_id'         => $tickets_id,
+         'groups_id'          => $groups_id,
+         'previous_groups_id' => $previous_groups_id,
+         'counter'            => $counter
       ]);
 
       //remove old user(s) (pass if user added by new ticket form)


### PR DESCRIPTION
Hello,

I want to add some informations in escalation history table :

Previous group assigned (Group A)
Counter of escalations between Group A (previous) and Group B (new assigned group)
New search option : total number of escalations in one ticket
New search option : total number of escalations in one ticket between 2 distincts groups