### PR TITLE
Check if current backtrace is ticket creation context, fixing formcreator conflict

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -220,13 +220,13 @@ class PluginEscaladeTicket {
       $keep_users_id = false;
 
       foreach ($backtraces as $backtrace) {
-        if ($backtrace['function'] == "add"
+         if ($backtrace['function'] == "add"
             && ($backtrace['object'] instanceOf CommonITILObject)) {
-           $keep_users_id = true;
-        }
+            $keep_users_id = true;
+         }
       }
       if (!$keep_users_id) {
-        self::removeAssignUsers($tickets_id);
+         self::removeAssignUsers($tickets_id);
       }
 
       //add a task to inform the escalation (pass if solution)

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -223,6 +223,7 @@ class PluginEscaladeTicket {
          if ($backtrace['function'] == "add"
             && ($backtrace['object'] instanceOf CommonITILObject)) {
             $keep_users_id = true;
+            break;
          }
       }
       if (!$keep_users_id) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -215,13 +215,18 @@ class PluginEscaladeTicket {
          'groups_id'  => $groups_id
       ]);
 
-      //remove old user(s) (pass if user added by new ticket form)
-      $backtrace   = debug_backtrace();
-      $first_trace = array_pop($backtrace);
-      if (strpos($first_trace['file'], 'ticket.form.php') === false
-          || $first_trace['function'] != "add"
-          || !($first_trace['object'] instanceOf Ticket)) {
-         self::removeAssignUsers($tickets_id);
+      //remove old user(s) (pass if user added by new ticket)
+      $backtraces   = debug_backtrace();
+      $keep_users_id = false;
+
+      foreach ($backtraces as $backtrace) {
+        if ($backtrace['function'] == "add"
+            && ($backtrace['object'] instanceOf CommonITILObject)) {
+           $keep_users_id = true;
+        }
+      }
+      if (!$keep_users_id) {
+        self::removeAssignUsers($tickets_id);
       }
 
       //add a task to inform the escalation (pass if solution)


### PR DESCRIPTION
Hello,

There is conflicts with escalations, formcreator and behavior (I think), steps to reproduce : 

- Behavior      : take first group of technician
- Escalation    : delete technicians on escalation
- Formcreator : in ticket target, set the assigned technician to form requester

Escalation remove current assigned technician if the first action in current backtrace isn't ticket add method, but when you submit a form, the first action is saveform, but you are indeed creating a ticket.

This PR solve this problem.