### PR TITLE
fix(core): fix undefined variable

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -250,10 +250,11 @@ class PluginEscaladeTicket {
 
       //check if event is not triggered by behaviors plugin
       //to prevent user remove when "add technician group" option is active
-      if (strpos($first_trace['file'], 'ticket.form.php') !== false
-         && $first_trace['function'] == "add"
-         && $first_trace['object'] instanceOf Ticket) {
-         return;
+      foreach ($backtraces as $backtrace) {
+         if ($backtrace['function'] == "add"
+            && ($backtrace['object'] instanceOf CommonITILObject)) {
+            return;
+         }
       }
 
       if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {


### PR DESCRIPTION
Refactor form duplication for better maintainability and testing

### Changes description

Fix PHP warning 

![image](https://user-images.githubusercontent.com/7335054/48115661-f1baf000-e263-11e8-905a-3d9ab1992a17.png)

This commit 5d17a33 cleaned up the call to backtrace, but the cleanup was not finished, a little further there was another call to $ first_trace

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #68 