### PR TITLE
Fix undefined 'glpiID' on CLI call; fixes #78

### DIFF
--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -277,7 +277,8 @@ class PluginEscaladeConfig extends CommonDBTM {
       $config->getFromDB(1);
       unset($config->fields['id']);
 
-      if (isset($config->fields['use_filter_assign_group'])
+      if (isset($_SESSION['glpiID'])
+          && isset($config->fields['use_filter_assign_group'])
           && $config->fields['use_filter_assign_group']) {
          $user = new PluginEscaladeUser();
          if ($user->getFromDBByCrit(['users_id' => $_SESSION['glpiID']])) {


### PR DESCRIPTION
To reproduce :
 - install and activate plugin,
 - enable filtering on the groups assignment:
   ![image](https://user-images.githubusercontent.com/33253653/56360575-64ea6a00-61e5-11e9-8bbf-efe5a1ba2f4d.png),
 - call `cron.php` using CLI.
