### PR TITLE
fix(core): display history even if no group is assigned

### DIFF
--- a/js/escalade.js.php
+++ b/js/escalade.js.php
@@ -28,7 +28,7 @@ if ($_SESSION['glpiactiveprofile']['interface'] == "central"
 
       //set active group in red
       $("table:contains('$locale_actor') td:last, .tab_actors .actor-bloc:last")
-         .find("a[href*=group]")
+         .find("a[onclick*=submitGetLink]")
          .addClass('escalade_active')
          .last()
          .append(


### PR DESCRIPTION
If if no group is assigned to ticket, previous history is not display.

![image](https://user-images.githubusercontent.com/7335054/72794791-d952ad80-3c3c-11ea-8bec-15cabeafd004.png)

This PR fix this

![image](https://user-images.githubusercontent.com/7335054/72794998-2f275580-3c3d-11ea-9695-3c1d1ec05b80.png)



see #82 