### PR TITLE
fix(core): do not notify old group

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -393,6 +393,8 @@ function plugin_escalade_item_add_ticket($item) {
 function plugin_escalade_pre_item_add_group_ticket($item) {
    if ($item instanceof Group_Ticket
        && $item->input['type'] == CommonITILActor::ASSIGN) {
+         //disable notification to prevent notification for old AND new group
+         $item->input['_disablenotif'] = true;
       return PluginEscaladeTicket::addHistoryOnAddGroup($item);
    }
    return $item;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -293,6 +293,13 @@ class PluginEscaladeTicket {
 
       //remove old groups (keep last assigned)
       self::removeAssignGroups($tickets_id, $groups_id);
+
+      //notified only the last group assigned
+      $ticket = new Ticket();
+      $ticket->getFromDB($tickets_id);
+
+      $event = "assign_".strtolower('Group');
+      NotificationEvent::raiseEvent($event, $ticket);
    }
 
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -298,7 +298,7 @@ class PluginEscaladeTicket {
       $ticket = new Ticket();
       $ticket->getFromDB($tickets_id);
 
-      $event = "assign_".strtolower('Group');
+      $event = "assign_group";
       NotificationEvent::raiseEvent($event, $ticket);
    }
 


### PR DESCRIPTION

When group is added to ticket,
plugin automatically remove old group, notification about new group assign is send to both.

1. An assign group is added to ticket
2. GLPI add group
3. GLPI sen dnotification about new group assign (send to both)
4. Plugin remove old group

this PR fix this

When a group is added, plugin is called from ```pre_item_add``` hook (on Group_Ticket) before add group
At this point this fix disabled notification ```$item->input['_disablenotif'] = true;```

When group is definitely added  (in DB) plugin is called from ```item_add``` hook
Plugin send notification about new group assign



 