### PR TITLE
Preserve INCOMING status

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -341,6 +341,13 @@ function plugin_escalade_item_purge($item) {
    return true;
 }
 
+function plugin_escalade_pre_item_update($item) {
+   if ($item instanceof Ticket) {
+      return PluginEscaladeTicket::pre_item_update($item);
+   }
+   return true;
+}
+
 function plugin_escalade_item_update($item) {
    if ($item instanceof Ticket) {
       return PluginEscaladeTicket::item_update($item);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -5,6 +5,17 @@ if (!defined('GLPI_ROOT')) {
 
 class PluginEscaladeTicket {
 
+   public static function pre_item_update(CommonDBTM $item) {
+      // If forcing INCOMING status on group change, prevent it from being
+      // dropped by take into account autocomputation
+      if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == CommonITILObject::INCOMING
+         && $item->fields['status'] == CommonITILObject::INCOMING
+         && ($item->input['_itil_assign']['groups_id'] ?? 0) > 0
+      ) {
+         $item->input['_do_not_compute_status'] = true;
+      }
+   }
+
    /**
     * Provide a redirection to other functions
     * @param  CommonDBTM $item

--- a/setup.php
+++ b/setup.php
@@ -112,6 +112,9 @@ function plugin_init_escalade() {
       $PLUGIN_HOOKS['add_css']['escalade'][]= 'css/escalade.css';
 
       // == Ticket modifications
+      $PLUGIN_HOOKS['pre_item_update']['escalade'] = [
+         'Ticket'       => 'plugin_escalade_pre_item_update',
+      ];
       $PLUGIN_HOOKS['item_update']['escalade']= [
          'Ticket'       => 'plugin_escalade_item_update',
       ];


### PR DESCRIPTION
!22700

Using this configuration:  

![image](https://user-images.githubusercontent.com/42734840/135260801-d50a95a2-ab6f-4999-9cf3-a7753c4a9961.png)

If a ticket is already in the "new" status then this rule won't be respected because of the take into account process (GLPI detect a new tech group -> take into account -> assigned status).
We need to send the correct flag to avoid this process.