### PR TITLE
Fix group view

### DIFF
--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -269,7 +269,7 @@ class PluginEscaladeHistory extends CommonDBTM {
          $options['criteria'][2]['value']      = 'mygroups';
          $options['criteria'][2]['link']       = 'AND';
 
-         echo "<div class='grid-item col-xl-6 col-xxl-4'><div class='card'>";
+         echo "<div class='grid-item col-xl-6 escalade-appended'><div class='card'>";
          echo "<div class='card-body p-0'>";
          echo "<div class='lazy-widget' data-itemtype='Ticket' data-widget='central_list'>";
          echo "<div class='table-responsive card-table'>";

--- a/js/central.js.php
+++ b/js/central.js.php
@@ -55,8 +55,9 @@ if ($_SESSION['glpiactiveprofile']['interface'] == "central"
                success : function(text)
                {
                   if (text !== "") {
-                     $(".masonry_grid").append(text);
-                     window.msnry = new Masonry('.masonry_grid');
+                     var target_masnry = $(".masonry_grid:visible");
+                     target_masnry.append(text);
+                     window['msnry_' + target_masnry.prop('id')].appended($(".escalade-appended"));
                   }
                }
             });


### PR DESCRIPTION
Javascript change in https://github.com/glpi-project/glpi/pull/12953 impact this plugin.
Also another PR removed the `col-xxl-4` class so it should be remove from the plugin too.

Before:

![image](https://user-images.githubusercontent.com/42734840/214551869-9f6317f8-953a-4859-8a4b-e9d816184517.png)

After: 

![image](https://user-images.githubusercontent.com/42734840/214551935-457d7c30-16bb-47ad-96cf-2bc29423c7fe.png)

Rather than creating a new layout, I've used masonry's `appended` method which is designed to handle this case.

