### PR TITLE
fix(solve) : prevent reopening ticket on solve

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -139,6 +139,7 @@ class PluginEscaladeTicket {
             $task->add([
                'tickets_id' => $tickets_id,
                'is_private' => true,
+               '_no_reopen' => true, //prevent reopening ticket
                'state'      => Planning::INFO,
                'content'    => __("Solution provided, back to the group", "escalade")." ".
                                $group->getName()


### PR DESCRIPTION
prevent reopening ticket on solve
(reopening because escalation plugin take first assign group to assign it to ticket after solved him)

fix : !28523