### PR TITLE
fix: ensure ticket status remains as 'new' after escalation

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -70,7 +70,7 @@ if (isset($_POST['escalate'])) {
 
         // retrieve the current status of the ticket
         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1) {
-            $previous_ticket_status = (new Ticket())->getById($tickets_id)->fields['status'];
+            $previous_ticket_status = Ticket::getById($tickets_id)->fields['status'];
         }
 
         $group_ticket->add([

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -67,12 +67,28 @@ if (isset($_POST['escalate'])) {
         ]);
 
         $group_ticket = new Group_Ticket();
+
+        $group_ticket_additional_data = [];
+
+        $a = (new Ticket())->getById($tickets_id);
+
+
+        // If 'ticket_last_status' is -1 (Do not modify) or Incoming, force the ticket not to update the status
+        if (
+            in_array(
+                $_SESSION['plugins']['escalade']['config']['ticket_last_status'],
+                [-1, CommonITILObject::INCOMING]
+            )
+        ) {
+            $group_ticket_additional_data['_from_object'] = true;
+        }
+
         $group_ticket->add([
             'type'       => CommonITILActor::ASSIGN,
             'groups_id'  => $group_id,
             'tickets_id' => $tickets_id,
             '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
-        ]);
+        ] + $group_ticket_additional_data);
     }
 }
 

--- a/hook.php
+++ b/hook.php
@@ -355,13 +355,6 @@ function plugin_escalade_item_purge($item) {
    return true;
 }
 
-function plugin_escalade_pre_item_update($item) {
-   if ($item instanceof Ticket) {
-      return PluginEscaladeTicket::pre_item_update($item);
-   }
-   return true;
-}
-
 function plugin_escalade_item_update($item) {
    if ($item instanceof Ticket) {
       return PluginEscaladeTicket::item_update($item);

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -346,6 +346,7 @@ class PluginEscaladeConfig extends CommonDBTM {
          'value' => $value,
          'width' => '80%',
          'rand' => $rand,
+         'display_emptychoice' => true,
       ]);
    }
 }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -39,9 +39,16 @@ class PluginEscaladeTicket {
    public static function pre_item_update(CommonDBTM $item) {
       // If forcing INCOMING status on group change, prevent it from being
       // dropped by take into account autocomputation
-      if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == CommonITILObject::INCOMING
-         && $item->fields['status'] == CommonITILObject::INCOMING
-         && ($item->input['_itil_assign']['groups_id'] ?? 0) > 0
+      if (
+         in_array(
+            $_SESSION['plugins']['escalade']['config']['ticket_last_status'],
+            [-1, CommonITILObject::INCOMING]
+         )
+         && $item->input['status'] == CommonITILObject::INCOMING
+         && !empty(array_filter(
+            $item->input['_actors']['assign'] ?? [],
+            fn ($actor) => $actor['itemtype'] == 'Group'
+         ))
       ) {
          $item->input['_do_not_compute_status'] = true;
       }

--- a/setup.php
+++ b/setup.php
@@ -113,9 +113,6 @@ function plugin_init_escalade() {
       $PLUGIN_HOOKS['add_css']['escalade'][]= 'css/escalade.css';
 
       // == Ticket modifications
-      $PLUGIN_HOOKS['pre_item_update']['escalade'] = [
-         'Ticket'       => 'plugin_escalade_pre_item_update',
-      ];
       $PLUGIN_HOOKS['item_update']['escalade']= [
          'Ticket'       => 'plugin_escalade_item_update',
       ];


### PR DESCRIPTION
!30921

## Description

This PR addresses a bug in the plugin where tickets would automatically change to the status 'in progress' after an escalation task, even when the desired configuration was set to 'new'. The issue was due to the group assignment altering the status.

## Changes

The fix involves a small change in the `ticket.form.php` file. A condition has been added to check if the last status of the ticket was 'incoming' and if the current status is 'incoming'. If both conditions are met, the `_from_object` key is set to true in the group ticket additional data variable. This key indicates to the add method that the status should not be altered during the group assignment.