### PR TITLE
fix: correct group filtering in escalation process

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -910,9 +910,10 @@ class PluginEscaladeTicket {
 
     public function showForm($ID, $options = [])
     {
+        $tickets_id = $options["parent"]->getID();
         $groups_assign = new Group_Ticket();
         $groups = $groups_assign->find([
-            'tickets_id' => $options["parent"]->getID(),
+            'tickets_id' => $tickets_id,
             'type' => CommonITILActor::ASSIGN,
         ]);
 
@@ -921,10 +922,18 @@ class PluginEscaladeTicket {
             $assigned_groups[$grp['groups_id']] = $grp['groups_id'];
         }
 
+        $PluginEscaladeGroup_Group = new PluginEscaladeGroup_Group();
+        $groups_id_filtered = array_keys($PluginEscaladeGroup_Group->getGroups($tickets_id));
+        $groups_id_filtered = empty($groups_id_filtered) ? [-1] : $groups_id_filtered;
+
         TemplateRenderer::getInstance()->display('@escalade/escalade_form.html.twig', [
             'action'          => PLUGIN_ESCALADE_WEBDIR . '/front/ticket.form.php',
             'ticket'          => $options['parent'],
             'assigned_groups' => $assigned_groups,
+            'condidition'     => [
+                'is_assign' => 1,
+                'id' => $groups_id_filtered,
+            ],
         ]);
     }
 }

--- a/templates/escalade_form.html.twig
+++ b/templates/escalade_form.html.twig
@@ -72,7 +72,7 @@
                             'required' : true,
                             'icon_label': true,
                             'entity': ticket.fields['entities_id'],
-                            'condition': {'is_assign': 1},
+                            'condition': condidition,
                             'value' : 0,
                             'used': assigned_groups,
                             'rand': rand,


### PR DESCRIPTION
!30933

## Description
This PR fixes an issue in the escalation process where all groups were being shown in the escalation task, regardless of the filtering rules in place. The expected behavior is that only the groups specified in the filtering rules should be available for escalation.

## Changes
- Added logic in `PluginEscaladeTicket::showForm` to get the filtered groups and pass them to the template.
- Updated the `escalade_form.html.twig` template to use the filtered groups for the 'condition' field.