### PR TITLE
fix: add short label to split action buttons in timeline footer

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -901,6 +901,7 @@ class PluginEscaladeTicket {
                 'class' => 'action-escalation',
                 'icon' => 'ti ti-arrow-up',
                 'label' => __('Escalate', 'escalade'),
+                'short_label' => __('Escalate', 'escalade'),
                 'item' => new self()
             ];
         }


### PR DESCRIPTION
## Description
This PR fixes a display issue in the timeline footer of a ticket. When the action button is split into multiple buttons, instead of its dropdown form, the button was displayed without a label, only with its icon. This fix ensures that a short label is displayed for the button.

![image](https://github.com/pluginsGLPI/escalade/assets/42278610/cdb06400-bbd6-4830-a49a-f630cce12480)

![image](https://github.com/pluginsGLPI/escalade/assets/42278610/30726317-cb6e-43b6-a96c-b09ecad0b0d5)

## Changes
- Added a 'short_label' to the action button configuration in `PluginEscaladeTicket` class.