### PR TITLE
Fix group dropdown in escalate form

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -922,19 +922,22 @@ class PluginEscaladeTicket {
         foreach ($groups as $grp) {
             $assigned_groups[$grp['groups_id']] = $grp['groups_id'];
         }
-
+        $config = new PluginEscaladeConfig();
+        $config->getFromDB(1);
         $PluginEscaladeGroup_Group = new PluginEscaladeGroup_Group();
         $groups_id_filtered = array_keys($PluginEscaladeGroup_Group->getGroups($tickets_id));
         $groups_id_filtered = empty($groups_id_filtered) ? [-1] : $groups_id_filtered;
-
+        $condition = [
+            'is_assign' => 1
+        ];
+        if ($config->fields['use_filter_assign_group']) {
+            $condition['id'] = $groups_id_filtered;
+        }
         TemplateRenderer::getInstance()->display('@escalade/escalade_form.html.twig', [
             'action'          => PLUGIN_ESCALADE_WEBDIR . '/front/ticket.form.php',
             'ticket'          => $options['parent'],
             'assigned_groups' => $assigned_groups,
-            'condidition'     => [
-                'is_assign' => 1,
-                'id' => $groups_id_filtered,
-            ],
+            'condition'     => $condition,
         ]);
     }
 }

--- a/templates/escalade_form.html.twig
+++ b/templates/escalade_form.html.twig
@@ -72,7 +72,7 @@
                             'required' : true,
                             'icon_label': true,
                             'entity': ticket.fields['entities_id'],
-                            'condition': condidition,
+                            'condition': condition,
                             'value' : 0,
                             'used': assigned_groups,
                             'rand': rand,


### PR DESCRIPTION
Fix group dropdown depending on the configuration 'use_filter_assign_group'