### PR TITLE
fix(Core): fix behavior from 'status' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix behavior for ```Ticket status after an escalation``` option
 
 ## [2.9.3] - 2024-02-21
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -79,7 +79,7 @@ if (isset($_POST['escalate'])) {
         ];
 
         //handle status behavior
-        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){ // no change
+        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){
             $group_ticket_input['_from_object']['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
         }
         $group_ticket_input['_from_object']['_do_not_compute_status'] = true;

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -79,11 +79,7 @@ if (isset($_POST['escalate'])) {
         ];
 
         //handle status behavior
-        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1){ // no change
-            $ticket = new Ticket();
-            $ticket->getFromDB($tickets_id);
-            $group_ticket_input['_from_object']['status'] = $ticket->fields['status']; //force current status
-        } else {
+        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){ // no change
             $group_ticket_input['_from_object']['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
         }
         $group_ticket_input['_from_object']['_do_not_compute_status'] = true;

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -71,13 +71,25 @@ if (isset($_POST['escalate'])) {
             ) . $_POST['comment']
         ]);
 
-        $group_ticket = new Group_Ticket();
-        $group_ticket->add([
+        $group_ticket_input = [
             'type'       => CommonITILActor::ASSIGN,
             'groups_id'  => $group_id,
             'tickets_id' => $tickets_id,
             '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
-        ]);
+        ];
+
+        //handle status behavior
+        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1){ // no change
+            $ticket = new Ticket();
+            $ticket->getFromDB($tickets_id);
+            $group_ticket_input['_from_object']['status'] = $ticket->fields['status']; //force current status
+        } else {
+            $group_ticket_input['_from_object']['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+        }
+        $group_ticket_input['_from_object']['_do_not_compute_status'] = true;
+
+        $group_ticket = new Group_Ticket();
+        $group_ticket->add($group_ticket_input);
     }
 }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -44,16 +44,12 @@ class PluginEscaladeTicket {
       )) && $item->input['_from_assignment']
       ){
          //handle status behavior
-         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1){ // no change
-            $item->input['status'] = $item->fields['status']; //force current status
-         } else {
+         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){ // no change
             $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
          }
       }
 
       $item->input['_do_not_compute_status'] = true;
-
-      Toolbox::logDebug($item->input['status']);
    }
 
    /**

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -44,7 +44,7 @@ class PluginEscaladeTicket {
       )) && $item->input['_from_assignment']
       ){
          //handle status behavior
-         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){ // no change
+         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){
             $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
          }
       }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -37,14 +37,23 @@ if (!defined('GLPI_ROOT')) {
 class PluginEscaladeTicket {
 
    public static function pre_item_update(CommonDBTM $item) {
-      // If forcing INCOMING status on group change, prevent it from being
-      // dropped by take into account autocomputation
-      if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == CommonITILObject::INCOMING
-         && $item->fields['status'] == CommonITILObject::INCOMING
-         && ($item->input['_itil_assign']['groups_id'] ?? 0) > 0
-      ) {
-         $item->input['_do_not_compute_status'] = true;
+      //only if update is related to Group assign operation and _from_assignment
+      if (!empty(array_filter(
+         $item->input['_actors']['assign'] ?? [],
+         fn ($actor) => $actor['itemtype'] == 'Group'
+      )) && $item->input['_from_assignment']
+      ){
+         //handle status behavior
+         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1){ // no change
+            $item->input['status'] = $item->fields['status']; //force current status
+         } else {
+            $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+         }
       }
+
+      $item->input['_do_not_compute_status'] = true;
+
+      Toolbox::logDebug($item->input['status']);
    }
 
    /**
@@ -313,7 +322,7 @@ class PluginEscaladeTicket {
             'tickets_id' => $tickets_id,
             'is_private' => true,
             'state'      => Planning::INFO,
-            'content'    => Toolbox::addslashes_deep(sprintf(__("Escalation to the group %s.", "escalade"), $group->getName()))
+            'content'    => Toolbox::addslashes_deep(sprintf(__("Escalation to the group %s.", "escalade"), $group->getName())),
          ]);
       }
 
@@ -420,14 +429,26 @@ class PluginEscaladeTicket {
       if (! $group_ticket->find($condition)) {
 
          // add group to ticket
-         $ticket = new Ticket();
-         $ticket->update([
-            'id' => $tickets_id,
-            '_itil_assign' => [
-               '_type'     => "group",
-               'groups_id' => $groups_id
-            ]
-         ]);
+         $group_ticket_input = [
+            'type'       => CommonITILActor::ASSIGN,
+            'groups_id'  => $groups_id,
+            'tickets_id' => $tickets_id,
+            '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+         ];
+
+         //handle status behavior
+         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1){ // no change
+            $ticket = new Ticket();
+            $ticket->getFromDB($tickets_id);
+            $group_ticket_input['_from_object']['status'] = $ticket->fields['id']; //force current status
+         } else {
+            $group_ticket_input['_from_object']['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+         }
+
+         $group_ticket_input['_from_object']['_do_not_compute_status'] = true;
+
+         $group_ticket = new Group_Ticket();
+         $group_ticket->add($group_ticket_input);
       }
 
       if (! $full_history) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -437,7 +437,7 @@ class PluginEscaladeTicket {
          ];
 
          //handle status behavior
-         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){ // no change
+         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){
             $group_ticket_input['_from_object']['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
          }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -437,11 +437,7 @@ class PluginEscaladeTicket {
          ];
 
          //handle status behavior
-         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] == -1){ // no change
-            $ticket = new Ticket();
-            $ticket->getFromDB($tickets_id);
-            $group_ticket_input['_from_object']['status'] = $ticket->fields['id']; //force current status
-         } else {
+         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1){ // no change
             $group_ticket_input['_from_object']['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
          }
 


### PR DESCRIPTION
Replace https://github.com/pluginsGLPI/escalade/pull/158

Fix behavior for ```Ticket status after an escalation```	

```Do not Change``` and other status are apllied.

The final problem concerns ```SLAs```
When status is  ```new``` the ```take into account is computed``` (they shouldn't be). 

Should fix : internal ref : 30921 and #93