### PR TITLE
feat: Limit group escalation to authorized groups

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -314,6 +314,13 @@ function plugin_escalade_install() {
       $migration->migrationOneTable('glpi_plugin_escalade_configs');
    }
 
+   // add new fields
+   if (!$DB->fieldExists('glpi_plugin_escalade_configs', 'limit_filter_assign_group')) {
+      $migration->addField('glpi_plugin_escalade_configs', 'limit_filter_assign_group',
+                           'integer', ['after' => 'use_filter_assign_group']);
+      $migration->migrationOneTable('glpi_plugin_escalade_configs');
+   }
+
    return true;
 }
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -302,7 +302,15 @@ class PluginEscaladeConfig extends CommonDBTM {
          'rand' => $rand,
       ]);
       echo "</td>";
-      echo "<td colspan='2'></td>";
+      echo "<td><label for='dropdown_limit_filter_assign_group$rand'>";
+      echo __("Limit filtering to the allowed groups by assigned groups", "escalade") . "</td>";
+      echo "<td>";
+      Dropdown::showYesNo("limit_filter_assign_group", $this->fields["limit_filter_assign_group"], -1, [
+         'width' => '100%',
+         'rand' => $rand,
+         'disabled' => $this->fields["use_filter_assign_group"] ?? 0 ? false : true,
+      ]);
+      echo "</td>";
       echo "</tr>";
 
       $options['candel']       = false;

--- a/inc/group_group.class.php
+++ b/inc/group_group.class.php
@@ -128,13 +128,20 @@ class PluginEscaladeGroup_Group extends CommonDBRelation {
    }
 
    function getGroups($ticket_id, $removeAlreadyAssigned = true) {
+      $config = new PluginEscaladeConfig();
+      $config->getFromDB(1);
       $groups = $user_groups = $ticket_groups = [];
 
       // get groups for user connected
       $tmp_user_groups  = Group_User::getUserGroups($_SESSION['glpiID']);
       foreach ($tmp_user_groups as $current_group) {
          $user_groups[$current_group['id']] = $current_group['id'];
-         $groups[$current_group['id']] = $current_group['id'];
+
+         // if we don't limit the list of groups to assign
+         // we add all groups of the user
+         if (!$config->fields['limit_filter_assign_group']) {
+            $groups[$current_group['id']] = $current_group['id'];
+         }
       }
 
       // get groups already assigned in the ticket
@@ -143,6 +150,12 @@ class PluginEscaladeGroup_Group extends CommonDBRelation {
          $ticket->getFromDB($ticket_id);
          foreach ($ticket->getGroups(CommonITILActor::ASSIGN) as $current_group) {
             $ticket_groups[$current_group['groups_id']] = $current_group['groups_id'];
+
+            // if we limit the list of groups to assign
+            // we add only groups already assigned to the ticket
+            if ($config->fields['limit_filter_assign_group']) {
+               $groups[$current_group['groups_id']] = $current_group['groups_id'];
+            }
          }
       }
 


### PR DESCRIPTION
This PR introduces a new feature that allows limiting group escalation to only the groups authorized by the current group(s). A new option has been added in the configuration to enable this feature.

Changes include:
- Addition of a new field `limit_filter_assign_group` in the `glpi_plugin_escalade_configs` table.
- Modification in the `PluginEscaladeConfig` class to include the new option in the configuration.
- Modification in the `PluginEscaladeGroup_Group` class to limit the groups available for escalation based on the new configuration option.