### PR TITLE
fix(Group filtering): return user group when no filtered group are available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix group filtering (empty group list) when no group is assigned to the ticket
 
 ## [2.9.3] - 2024-02-21
 

--- a/inc/group_group.class.php
+++ b/inc/group_group.class.php
@@ -184,8 +184,8 @@ class PluginEscaladeGroup_Group extends CommonDBRelation {
          $groupname = $group_obj->fields['name'];
       }
 
-      //if empty retun user groups
-      if (empty($groups)) {
+      //if empty new tickets return user groups
+      if (empty($groups) && CommonDBTM::isNewID($ticket_id)) {
          return Group_User::getUserGroups($_SESSION['glpiID']);
       }
 

--- a/inc/group_group.class.php
+++ b/inc/group_group.class.php
@@ -184,6 +184,11 @@ class PluginEscaladeGroup_Group extends CommonDBRelation {
          $groupname = $group_obj->fields['name'];
       }
 
+      //if empty retun user groups
+      if (empty($groups)) {
+         return Group_User::getUserGroups($_SESSION['glpiID']);
+      }
+
       //sort by group name (and keep associative index)
       asort($groups);
 


### PR DESCRIPTION
With ```Enable filtering on the groups assignment``` option  enabled

When no group is assigned to the ticket, the list of actors contains no group (we should have all the user's groups logged in).

as soon as a group is assigned, group filtering works correctly

Fix #171 