### PR TITLE
Fix(Group filtering): Revert to old group filtering behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 
+### Fixed
+- Fix group filtering
+
+
 ## [2.9.3] - 2024-02-21
 
 ### Added

--- a/inc/group_group.class.php
+++ b/inc/group_group.class.php
@@ -183,6 +183,10 @@ class PluginEscaladeGroup_Group extends CommonDBRelation {
          $groupname = $group_obj->fields['name'];
       }
 
+      if (count($groups) == 0) {
+         Group_User::getUserGroups($_SESSION['glpiID']);
+      }
+
       //sort by group name (and keep associative index)
       asort($groups);
 

--- a/setup.php
+++ b/setup.php
@@ -139,9 +139,11 @@ function plugin_init_escalade() {
       $PLUGIN_HOOKS['item_add']['escalade']['User'] = 'plugin_escalade_item_add_user';
 
       //filter group feature
-      $PLUGIN_HOOKS[Hooks::FILTER_ACTORS]['escalade'] = [
-         'PluginEscaladeTicket', 'filter_actors',
-      ];
+      if ($escalade_config['use_filter_assign_group']) {
+         $PLUGIN_HOOKS[Hooks::FILTER_ACTORS]['escalade'] = [
+            'PluginEscaladeTicket', 'filter_actors',
+         ];
+      }
 
       // == Interface links ==
       if (Session::haveRight('config', UPDATE)) {


### PR DESCRIPTION
Revert to old group filtering behaviour

Bug introduced by https://github.com/pluginsGLPI/escalade/pull/167

This PR fix current behavior while fixing the problem on #167

should fix #173, #171, internal ref 31866, internal ref 31926, internal ref 31951