### PR TITLE
Add post update processing to prevent unauthorized deletion of ticket actors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.9.5] - 2024-05-06
+## [unreleased] - 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.9.4] - 20204-04-03
+## [2.9.5] - 2024-05-06
+
+### Fixed
+
+- Fix unauthorized deletion of ticket actors according to plugin configuration
+
+## [2.9.4] - 2024-04-03
 
 ### Fixed
 


### PR DESCRIPTION
Escalade allows the deletion of technician groups assigned to tickets despite the _**Show delete button**_ option being set to **No** in the plugin configuration.

Related ticket : 32414