### PR TITLE
Fix unsended notifications while 'Delete old groups when adding a new one' is set to 'No'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.9.4] - 20204-04-03
+## [2.9.5] - 2024-05-06
+
+### Fixed
+
+- Fix unsended notifications while `Delete old groups when adding a new one` is set to `No`
+
+## [2.9.4] - 2024-04-03
 
 ### Fixed
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -352,17 +352,15 @@ class PluginEscaladeTicket
 
     public static function processAfterAddGroup(CommonDBTM $item)
     {
-        if ($_SESSION['plugins']['escalade']['config']['remove_group'] == false) {
-            return true;
+        $tickets_id = $item->fields['tickets_id'];
+        $groups_id = $item->fields['groups_id'];
+
+        //remove old groups (keep last assigned)
+        if ($_SESSION['plugins']['escalade']['config']['remove_group'] == true) {
+            self::removeAssignGroups($tickets_id, $groups_id);
         }
 
-        $tickets_id = $item->fields['tickets_id'];
-        $groups_id  = $item->fields['groups_id'];
-
-       //remove old groups (keep last assigned)
-        self::removeAssignGroups($tickets_id, $groups_id);
-
-       //notified only the last group assigned
+        //notified only the last group assigned
         $ticket = new Ticket();
         $ticket->getFromDB($tickets_id);
 


### PR DESCRIPTION
When the option "Delete old groups when adding a new group" is set to "No" and the ticket is escalated, the 'assign_group' event notification is not sent

Related ticket : 32782