### PR TITLE
fix GLPI compatibility

### DIFF
--- a/escalade.xml
+++ b/escalade.xml
@@ -63,7 +63,7 @@ Elle ajoute les fonctionnalités suivantes :
    <versions>
       <version>
          <num>2.9.5</num>
-         <compatibility>~10.0.0</compatibility>
+         <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.5/glpi-escalade-2.9.5.tar.bz2</download_url>
       </version>
       <version>


### PR DESCRIPTION
Due to this -> https://github.com/pluginsGLPI/escalade/pull/184

Since version 2.9.5, the plugin is only compatible with GLPI version 10.0.11.

But ```plugin.xml``` indicates compatibility with all versions of GLPI 10.0.x

fix : #193 