### PR TITLE
Prevent unselection of actors who cannot be removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.9.5] - 2024-05-17
+## [unreleased]
 
 ### Fixed
 
 - Prevent unselection of actors who cannot be removed
+
+## [2.9.5] - 2024-05-06
+
+### Fixed
+
+- Fix unauthorized deletion of ticket actors according to plugin configuration
+- Fix unsended notifications while `Delete old groups when adding a new one` is set to `No`
 
 ## [2.9.4] - 2024-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.9.5] - 2024-05-06
+## [2.9.5] - 2024-05-17
 
 ### Fixed
 
-- Fix unauthorized deletion of ticket actors according to plugin configuration
-- Fix unsended notifications while `Delete old groups when adding a new one` is set to `No`
+- Prevent unselection of actors who cannot be removed
 
 ## [2.9.4] - 2024-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Prevent unselection of actors who cannot be removed
+- Fix ```Display delete button``` option
 
 ## [2.9.5] - 2024-05-06
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -54,8 +54,6 @@ class PluginEscaladeTicket
         if (isset($input['_itil_assign'])) {
             $item->input['_do_not_compute_status'] = true;
         }
-<<<<<<< HEAD
-
         $config = $_SESSION['plugins']['escalade']['config'];
 
         // Get actual actors for the ticket
@@ -101,8 +99,6 @@ class PluginEscaladeTicket
                 }
             }
         }
-=======
->>>>>>> 363c042 (Prevent unselection of players who cannot be removed)
     }
 
    /**

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -43,11 +43,7 @@ class PluginEscaladeTicket
             !empty(array_filter(
                 $item->input['_actors']['assign'] ?? [],
                 fn ($actor) => $actor['itemtype'] == 'Group'
-            ))
-            && (
-                isset($item->input['_from_assignment'])
-                && $item->input['_from_assignment']
-            )
+            )) && $item->input['_from_assignment']
         ) {
            //handle status behavior
             if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
@@ -58,6 +54,7 @@ class PluginEscaladeTicket
         if (isset($input['_itil_assign'])) {
             $item->input['_do_not_compute_status'] = true;
         }
+<<<<<<< HEAD
 
         $config = $_SESSION['plugins']['escalade']['config'];
 
@@ -104,6 +101,8 @@ class PluginEscaladeTicket
                 }
             }
         }
+=======
+>>>>>>> 363c042 (Prevent unselection of players who cannot be removed)
     }
 
    /**

--- a/js/remove_btn.js.php
+++ b/js/remove_btn.js.php
@@ -203,8 +203,6 @@ if ($_SESSION['glpiactiveprofile']['interface'] == "central") {
          || location.pathname.indexOf('problem.form.php') > 0
          || location.pathname.indexOf('change.form.php') > 0) {
          $(document).on('glpi.tab.loaded', function() {
-            // requester_form.on('select2:select', handleEvent);
-            // requester_form.on('select2:unselect', handleEvent);
             let buttons_to_delete = {
                Group: {
                   requester: {$remove_delete_requester_group_btn},

--- a/js/remove_btn.js.php
+++ b/js/remove_btn.js.php
@@ -115,6 +115,60 @@ if ($_SESSION['glpiactiveprofile']['interface'] == "central") {
       return true;
    }
 
+   let getActorsAlreadyPresent = function(buttons_to_delete) {
+      let actors = [];
+      for (const [itemtype, actortypes] of Object.entries(buttons_to_delete)) {
+         for (const [actortype, to_delete] of Object.entries(actortypes)) {
+               if (to_delete) {
+                  let requester_form = $('.form-select.select2-hidden-accessible[data-actor-type='+actortype+']');
+                  let select2_input = requester_form.next('.select2-container').find('.select2-selection.select2-selection--multiple.actor-field');
+                  let select2_choices = select2_input.find('span.actor_entry');
+                  if (!actors[actortype]) {
+                     actors[actortype] = [];
+                  }
+                  select2_choices.each(function() {
+                     let item_id = $(this).data('items-id');
+                     let itemtype = $(this).data('itemtype');
+                     let exists = actors[actortype].some(el => el.item_id === item_id && el.itemtype === itemtype);
+
+                     if (!exists) {
+                           actors[actortype].push({
+                              item_id: item_id,
+                              itemtype: itemtype
+                           });
+                     }
+                  });
+               }
+         }
+      }
+      return actors;
+   }
+
+   var removeDeleteButtonForPreviousActors = function(actorslist) {
+      for (const actortype of actorslist) {
+         var requester_form = $(".form-select.select2-hidden-accessible[data-actor-type="+actortype+"]");
+         requester_form.on('select2:selecting', handleEvent);
+         requester_form.on('select2:open', handleEvent);
+         function handleEvent() {
+            for(const [item_id, itemtype] of actortype) {
+               setTimeout(function() {
+                  removeDeleteButtonForOne(itemtype, item_id, actortype, requester_form);
+               }, 50);
+            }
+         }
+      }
+   }
+
+   var removeDeleteButtonForOne = function(itemtype, item_id, actortype, form) {
+      var select2_container = form.next('.select2-container');
+      var select2_choice = select2_container.find(".select2-selection.select2-selection--multiple.actor-field span.actor_entry[data-itemtype="+itemtype+"][data-items-id="+item_id+"][data-actortype="+actortype+"]").first();
+      // Remove "x" from select2 tag
+      select2_choice.prev('.select2-selection__choice__remove').remove();
+
+      // Data is loaded
+      return true;
+   }
+
    var removeAllDeleteButtons = function(buttons_to_delete) {
       // Iterate on all itemtype + actortype combinations
       for (const [itemtype, actortypes] of Object.entries(buttons_to_delete)) {
@@ -129,12 +183,28 @@ if ($_SESSION['glpiactiveprofile']['interface'] == "central") {
       return buttons_to_delete;
    }
 
+   var actorCanBeRemoved = function(actortype, data, actors) {
+      if (actors === undefined || actors === null || data.id === undefined || data.id === null) {
+         return false;
+      }
+      var parts = data.id.split("_");
+      var item_id = parts[1];
+      var itemtype = parts[0];
+      var actorValues = Object.values(actors);
+      var exists = actorValues.some(function(el) {
+         return el.item_id == item_id && el.itemtype == itemtype;
+      });
+      return exists;
+   }
+
    $(document).ready(function() {
       // only in ticket form
       if (location.pathname.indexOf('ticket.form.php') > 0
          || location.pathname.indexOf('problem.form.php') > 0
          || location.pathname.indexOf('change.form.php') > 0) {
          $(document).on('glpi.tab.loaded', function() {
+            // requester_form.on('select2:select', handleEvent);
+            // requester_form.on('select2:unselect', handleEvent);
             let buttons_to_delete = {
                Group: {
                   requester: {$remove_delete_requester_group_btn},
@@ -150,6 +220,36 @@ if ($_SESSION['glpiactiveprofile']['interface'] == "central") {
                   assign: {$remove_delete_assign_supplier_btn},
                }
             };
+
+            var actors = getActorsAlreadyPresent(buttons_to_delete);
+            function handleRemoveDeletebuttonForOne(actortype_key, form) {
+               return function() {
+                  if (actors[actortype_key] === null || actors[actortype_key] === undefined ) {
+                     return false;
+                  }
+                  for(const [item_key, item_value] of Object.entries(actors[actortype_key])) {
+                     setTimeout(function() {
+                        removeDeleteButtonForOne(item_value['itemtype'], item_value['item_id'], actortype_key, form);
+                     }, 50);
+                  }
+               }
+            }
+
+            var actortypes = ['assign', 'requester', 'observer'];
+            for (var i = 0; i < actortypes.length; i++) {
+               let form = $(".form-select.select2-hidden-accessible[data-actor-type='" + actortypes[i] + "']");
+
+               form.on('select2:select', handleRemoveDeletebuttonForOne(actortypes[i], form));
+               form.on('select2:open', handleRemoveDeletebuttonForOne(actortypes[i], form));
+               form.on('select2:unselecting', function(e) {
+                  let data = e.params.args.data;
+                  let actortype = form.data('actor-type');
+                  if (actorCanBeRemoved(actortype, data, actors[actortype])) {
+                     e.preventDefault();
+                  }
+               });
+               form.on('select2:unselect', handleRemoveDeletebuttonForOne(actortypes[i], form));
+            }
             buttons_to_delete = removeAllDeleteButtons(buttons_to_delete);
 
             // as the ticket loading may be long, try to remove until 10s pass


### PR DESCRIPTION
It was possible to delete users from a ticket even when this was supposed to be blocked by the plugin's configuration. 
now the modification is logged in the backend as well as the front end

**Before**
![Screencast-from-17-05-2024-11_17_57](https://github.com/pluginsGLPI/escalade/assets/107540223/01abdfd2-98a2-410a-a902-360b0b84b920)

**After**
![Screencast-from-17-05-2024-11_15_08](https://github.com/pluginsGLPI/escalade/assets/107540223/0e19afe3-cc21-4bb8-a4d2-bfe19f972817)
