### PR TITLE
Add option for assign as observer default value

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -71,6 +71,7 @@ function plugin_escalade_install()
          `reassign_tech_from_cat`                  INT NOT NULL,
          `cloneandlink_ticket`                     INT NOT NULL,
          `close_linkedtickets`                     INT NOT NULL,
+         `assign_me_as_observer`                   INT NOT NULL,
          `use_assign_user_group`                   INT NOT NULL,
          `use_assign_user_group_creation`          INT NOT NULL,
          `use_assign_user_group_modification`      INT NOT NULL,
@@ -89,7 +90,7 @@ function plugin_escalade_install()
         $DB->doQuery($query);
 
         $query = "INSERT INTO glpi_plugin_escalade_configs
-      VALUES (NULL, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, '" . Ticket::WAITING . "',0)";
+      VALUES (NULL, 1, 1, 1, 1, 1, 0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, '" . Ticket::WAITING . "',0)";
         $DB->doQuery($query);
     }
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -188,6 +188,16 @@ class PluginEscaladeConfig extends CommonDBTM
 
         $rand = mt_rand();
         echo "<tr class='tab_bg_1'>";
+        echo "<td><label for='dropdown_assign_me_as_observer$rand'>";
+        echo __("Assign me as observer by default", "escalade") . "</label></td>";
+        echo "<td>";
+        Dropdown::showYesNo("assign_me_as_observer", $this->fields["assign_me_as_observer"], -1, [
+            'on_change' => 'hide_show_history(this.value)',
+            'width' => '25%',
+            'rand' => $rand,
+        ]);
+
+        $rand = mt_rand();
         echo "<td><label for='dropdown_use_assign_user_group$rand'>" . __("Use the technician's group", "escalade") . "</label></td>";
         echo "<td>";
         Dropdown::showFromArray('use_assign_user_group', $yesnoall, [

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1045,6 +1045,7 @@ class PluginEscaladeTicket
         TemplateRenderer::getInstance()->display('@escalade/escalade_form.html.twig', [
             'action'          => PLUGIN_ESCALADE_WEBDIR . '/front/ticket.form.php',
             'ticket'          => $options['parent'],
+            'assign_me_as_observer' => $config->fields['assign_me_as_observer'],
             'assigned_groups' => $assigned_groups,
             'condition'     => $condition,
         ]);

--- a/templates/escalade_form.html.twig
+++ b/templates/escalade_form.html.twig
@@ -81,7 +81,7 @@
                 </div>
                 {{ fields.checkboxField(
                     'is_observer_checkbox',
-                    1,
+                    0,
                     __('Assign me as an observer', 'escalade'),
                     {
                         'field_class': 'col-12',

--- a/templates/escalade_form.html.twig
+++ b/templates/escalade_form.html.twig
@@ -81,7 +81,7 @@
                 </div>
                 {{ fields.checkboxField(
                     'is_observer_checkbox',
-                    0,
+                    assign_me_as_observer,
                     __('Assign me as an observer', 'escalade'),
                     {
                         'field_class': 'col-12',


### PR DESCRIPTION
The customer requests that the “Assign me as observer” box be unchecked by default.
![image](https://github.com/pluginsGLPI/escalade/assets/102067890/5a576f0a-a14d-4bb3-8047-90a2b8c7bee5)


Related ticket : 33253