### PR TITLE
Fix(Option): fix 'use technician group' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unrelease] -
+
+### Fixed
+
+- Fix ```use technician group``` option
+
 ## [2.9.6] - 2024-05-17
 
 ### Fixed

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -450,14 +450,14 @@ class PluginEscaladeTicket
             isset($ticket->input['_users_id_assign'])
             && $ticket->input['_users_id_assign'] > 0
             && (!isset($ticket->input['_groups_id_assign'])
-                || $ticket->input['_groups_id_assign'] <= 0)
+                || empty($ticket->input['_groups_id_assign']))
         ) {
             if ($_SESSION['plugins']['escalade']['config']['use_assign_user_group'] == 1) {
                 // First group
                 $ticket->input['_groups_id_assign']
                     = PluginEscaladeUser::getTechnicianGroup(
                         $ticket->input['entities_id'],
-                        $ticket->input['_users_id_assign'],
+                        current($ticket->input['_users_id_assign']),
                         true
                     );
                 //prevent adding empty group


### PR DESCRIPTION
 Fix ```use technician group``` option that no longer work on creation

```$ticket->input['_groups_id_assign']``` and ```$ticket->input['_users_id_assign']``` are now an array (checks must be carried out in different ways)

Fix : !33591