### PR TITLE
2.9.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+
+## [2.9.7] - 2024-07-04
+
 ### Added
 
 - Add config option for default assignation
@@ -14,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix rules execution before escalation
-- Set assign as observer unchecked by default
+- Set ```assign as observer``` unchecked by default
 - Fixed ```blocking of user deletion```
 - Fix ```use technician group``` option
 

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.9.7</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.7/glpi-escalade-2.9.7.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.6</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.6/glpi-escalade-2.9.6.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.6');
+define('PLUGIN_ESCALADE_VERSION', '2.9.7');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.7] - 2024-07-04

### Added

- Add config option for default assignation

### Fixed

- Fix rules execution before escalation
- Set ```assign as observer``` unchecked by default
- Fixed ```blocking of user deletion```
- Fix ```use technician group``` option