### PR TITLE
Fix climbing with history & update full history window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Prevent an escalation when a ticket is updated
+- Fix climbing with history
+
+### Changed
+
+- Full history window (now is a modal)
 
 ## [2.9.7] - 2024-07-04
 

--- a/front/climb_group.php
+++ b/front/climb_group.php
@@ -37,6 +37,4 @@ if (
     Html::displayErrorAndDie(__("missing parameters", "escalade"));
 }
 
-$full_history = (isset($_REQUEST['full_history']));
-
-PluginEscaladeTicket::climb_group($_REQUEST['tickets_id'], $_REQUEST['groups_id'], $full_history);
+PluginEscaladeTicket::climb_group($_REQUEST['tickets_id'], $_REQUEST['groups_id']);

--- a/front/popup_histories.php
+++ b/front/popup_histories.php
@@ -30,10 +30,6 @@
 
 include("../../../inc/includes.php");
 
-Html::popHeader(__("full assignation history", "escalade"), $_SERVER['PHP_SELF']);
-echo "<div class='center'><br><a href='javascript:window.close()'>" . __("Close") . "</a>";
-echo "</div>";
-
 echo "<div id='page'>";
 PluginEscaladeHistory::getHistory($_REQUEST['tickets_id'], true);
 echo "</div>";

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -497,7 +497,7 @@ class PluginEscaladeTicket
      * @param  int $groups_id  the group to assign
      * @return void
      */
-    public static function climb_group($tickets_id, $groups_id, $full_history = false)
+    public static function climb_group($tickets_id, $groups_id)
     {
         //don't add group if already exist for this ticket
         $group_ticket = new Group_Ticket();
@@ -517,8 +517,9 @@ class PluginEscaladeTicket
             if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
                 $_form_object['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
             }
+            $ticket_details = $_POST['ticket_details'] ?? $_GET['ticket_details'] ?? [];
             $updates_ticket = new Ticket();
-            $updates_ticket->update($_POST['ticket_details'] + [
+            $updates_ticket->update($ticket_details + [
                 '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $groups_id),
                 '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
                 'actortype' => CommonITILActor::ASSIGN,
@@ -527,17 +528,7 @@ class PluginEscaladeTicket
             ]);
         }
 
-        if (!$full_history) {
-            Html::back();
-        } else {
-            //reload parent window and close popup
-            echo "<script type='text/javascript'>
-            if (window.opener && !window.opener.closed) {
-               window.opener.location.reload();
-            }
-            window.close();
-         </script>";
-        }
+        Html::back();
     }
 
 


### PR DESCRIPTION
Related ticket : 33695 and 33706

Escalation by history has been broken by this PR : https://github.com/pluginsGLPI/escalade/pull/200

Here is the assignment history : 
![image](https://github.com/pluginsGLPI/escalade/assets/102067890/ebd0f732-295c-43a9-a20c-b1d3b26f9f8a)

However, when climbing through this history, the following errors occur
![image](https://github.com/pluginsGLPI/escalade/assets/102067890/2001e5cd-93ec-4155-9561-cdc3d19727e0)

The changes made to fix this problem have resulted in a change to the full history window to a modal:

Before : Window
![image](https://github.com/pluginsGLPI/escalade/assets/102067890/b4785adf-5920-45e3-9e7a-4a666f8d7e12)

After : Modal
![image](https://github.com/pluginsGLPI/escalade/assets/102067890/0365bb2a-3650-44e2-b4a0-dce2dfd2a841)
