### PR TITLE
Fix climbing triggered when ticket is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+### Fixed
+
+- Trigger escalation for ticket updates not related to the plugin
 
 ## [2.9.7] - 2024-07-04
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -111,15 +111,16 @@ class PluginEscaladeTicket
                     $item->input['actortype'] = CommonITILActor::ASSIGN;
                 }
             }
+        } else {
+            if (
+                (isset($item->input['actortype']) && $item->input['actortype'] == CommonITILActor::ASSIGN)
+            ) {
+                //disable notification to prevent notification for old AND new group
+                $item->input['_disablenotif'] = true;
+                return PluginEscaladeTicket::addHistoryOnAddGroup($item);
+            }
+            return $item;
         }
-        if (
-            (isset($item->input['actortype']) && $item->input['actortype'] == CommonITILActor::ASSIGN)
-        ) {
-            //disable notification to prevent notification for old AND new group
-            $item->input['_disablenotif'] = true;
-            return PluginEscaladeTicket::addHistoryOnAddGroup($item);
-        }
-        return $item;
     }
 
     /**


### PR DESCRIPTION
Related ticket : 33742 and 33767
Problem added by the PR : #200 

When a ticket is updated with fields that have nothing to do with the Escalade plugin, an escalation is triggered anyway.

![image](https://github.com/pluginsGLPI/escalade/assets/102067890/11f741e5-db87-420b-9964-0fa77971a504)
