### PR TITLE
Fix users (tech & requester) not being deleted during escalation

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -105,10 +105,12 @@ class PluginEscaladeTicket
         if (!isset($item->input['actortype'])) {
             $groups = new Group_Ticket();
             $groups = $groups->find(['tickets_id' => $item->getID(), 'type' => CommonITILActor::ASSIGN]);
-            foreach ($item->input['_actors']['assign'] as $actors) {
-                if ($actors['itemtype'] == 'Group' && !in_array($actors['items_id'], $groups)) {
-                    $item->input['groups_id'] = $actors['items_id'];
-                    $item->input['actortype'] = CommonITILActor::ASSIGN;
+            if (!empty($item->input['_actors'])) {
+                foreach ($item->input['_actors']['assign'] as $actors) {
+                    if ($actors['itemtype'] == 'Group' && !in_array($actors['items_id'], $groups)) {
+                        $item->input['groups_id'] = $actors['items_id'];
+                        $item->input['actortype'] = CommonITILActor::ASSIGN;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Related ticket : 33695

Continuation of this PR : #212 

These two parameters in the configuration allow you to remove users from the actors in a ticket after an escalation. But this feature was no longer working.

![image](https://github.com/user-attachments/assets/da293462-3261-44c5-b728-13e34cfe8f18)
![image](https://github.com/user-attachments/assets/6fa7b85d-39f1-4926-a558-1f5a00cf2f2b)
