### PR TITLE
Fix escalation history

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -58,6 +58,7 @@ class PluginEscaladeTicket
             $item->input['_do_not_compute_status'] = true;
         }
         $config = $_SESSION['plugins']['escalade']['config'];
+        $actors_count = 0;
 
         // Get actual actors for the ticket
         if ($item instanceof Ticket) {
@@ -70,6 +71,10 @@ class PluginEscaladeTicket
                 },
                 []
             );
+
+            $actors_count = count(array_filter($ticket_actors['assign'], function ($actor) {
+                return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
+            }));
 
             // Get deletion rights for each type of actor
             $deletion_rights = [
@@ -113,9 +118,16 @@ class PluginEscaladeTicket
                     }
                 }
             }
-        } else {
+        }
+        if (
+            isset($item->input['_actors']['assign'])
+        ) {
+            $input_actors_count = count(array_filter($item->input['_actors']['assign'], function ($actor) {
+                return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
+            }));
             if (
-                (isset($item->input['actortype']) && $item->input['actortype'] == CommonITILActor::ASSIGN)
+                (isset($item->input['actortype']) && $item->input['actortype'] == CommonITILActor::ASSIGN) &&
+                $actors_count < $input_actors_count
             ) {
                 //disable notification to prevent notification for old AND new group
                 $item->input['_disablenotif'] = true;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -137,13 +137,11 @@ class PluginEscaladeTicket
             } else if (count($old_actors) == count($new_actors)) {
                 $old_actor_names = [];
                 foreach ($old_actors as $old_actor) {
-                    $old_actor_names[$old_actor['text']] = true;
+                    $old_actor_names[$old_actor['items_id']] = true;
                 }
 
-                // Parcourir les nouveaux acteurs et vérifier si leur nom existe dans le tableau associatif
                 foreach ($new_actors as $new_actor) {
-                    $name = Group::getFriendlyNameById($new_actor['items_id']);
-                    if (!isset($old_actor_names[$name])) {
+                    if (!isset($old_actor_names[$new_actor['items_id']])) {
                         $item->input['_disablenotif'] = true;
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -58,7 +58,7 @@ class PluginEscaladeTicket
             $item->input['_do_not_compute_status'] = true;
         }
         $config = $_SESSION['plugins']['escalade']['config'];
-        $old_actors = [];
+        $old_groups = [];
 
         // Get actual actors for the ticket
         if ($item instanceof Ticket) {
@@ -72,7 +72,7 @@ class PluginEscaladeTicket
                 []
             );
 
-            $old_actors = array_filter($ticket_actors['assign'], function ($actor) {
+            $old_groups = array_filter($ticket_actors['assign'], function ($actor) {
                 return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
             });
 
@@ -122,26 +122,26 @@ class PluginEscaladeTicket
         if (
             isset($item->input['_actors']['assign'])
         ) {
-            $new_actors = array_filter($item->input['_actors']['assign'], function ($actor) {
+            $new_groups = array_filter($item->input['_actors']['assign'], function ($actor) {
                 return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
             });
             if (
                 (isset($item->input['actortype']) && $item->input['actortype'] == CommonITILActor::ASSIGN) &&
                 (
-                    count($old_actors) < count($new_actors)
+                    count($old_groups) < count($new_groups)
                 )
             ) {
                 //disable notification to prevent notification for old AND new group
                 $item->input['_disablenotif'] = true;
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
-            } else if (count($old_actors) == count($new_actors)) {
-                $old_actor_names = [];
-                foreach ($old_actors as $old_actor) {
-                    $old_actor_names[$old_actor['items_id']] = true;
+            } else if (count($old_groups) == count($new_groups)) {
+                $old_group_ids = [];
+                foreach ($old_groups as $old_group) {
+                    $old_group_ids[$old_group['items_id']] = true;
                 }
 
-                foreach ($new_actors as $new_actor) {
-                    if (!isset($old_actor_names[$new_actor['items_id']])) {
+                foreach ($new_groups as $new_group) {
+                    if (!isset($old_group_ids[$new_group['items_id']])) {
                         $item->input['_disablenotif'] = true;
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | !33742

Fixed the fact that the escalation history no longer appeared when the assigned groups were changed from the ticket form.