### PR TITLE
Fix task added from ajax climb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Prevent an escalation when a ticket is updated
 - Fix climbing with history
+- Fix task not added when climbing with history
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Prevent an escalation when a ticket is updated
-- Fix climbing with history
-- Fix task not added when climbing with history
+- Fix escalating with history
+- Fix task not added when escalating with history
 
 ### Changed
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -547,7 +547,7 @@ class PluginEscaladeTicket
             $updates_ticket = new Ticket();
             $updates_ticket->update($ticket_details + [
                 '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $groups_id),
-                '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+                '_plugin_escalade_no_history' => false,
                 'actortype' => CommonITILActor::ASSIGN,
                 'groups_id' => $groups_id,
                 '_form_object' => $_form_object,


### PR DESCRIPTION
When using history to clib to specific group
![image](https://github.com/user-attachments/assets/52a537f5-2d29-4fce-b212-502ba1544109)

related task is not added

![image](https://github.com/user-attachments/assets/5f7c0320-1085-4fa5-8a6e-e52f5a9f9759)

nb : since https://github.com/pluginsGLPI/escalade/pull/200/files (bad copy paste)