### PR TITLE
Fix(Core): prevent php warning

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -604,7 +604,7 @@ class PluginEscaladeTicket
             return true;
         }
 
-        $tickets_id = $item->input['id'];
+        $tickets_id = $item->input['id'] ?? $item->fields['id'];
 
         $where_keep = [
             'tickets_id' => $tickets_id,


### PR DESCRIPTION
Using self assignment 

![image](https://github.com/user-attachments/assets/29eb68fd-dc9e-4918-95aa-23d641967804)

raises up a php warning

```
   {"user":"2@stanislas-asus-desktop"} 
[2024-08-27 13:24:55] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "id" in /home/DEV/GLPI/10.0-bugfixes/plugins/escalade/inc/ticket.class.php at line 610
  Backtrace :
  plugins/escalade/inc/ticket.class.php:674          PluginEscaladeTicket::removeAssignUsers()
  plugins/escalade/hook.php:482                      PluginEscaladeTicket::item_add_user()
  src/Plugin.php:1713                                plugin_escalade_item_add_user()
  src/CommonDBTM.php:1390                            Plugin::doHook()
  src/CommonITILObject.php:1987                      CommonDBTM->add()
  src/Ticket.php:1345                                CommonITILObject->prepareInputForUpdate()
  src/CommonDBTM.php:1613                            Ticket->prepareInputForUpdate()
  front/ticket.form.php:210                          CommonDBTM->update()
  public/index.php:82                                require()
```