### PR TITLE
Fix(Core): Fix status after escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Correction of the task message generated during escalation
+- Fix task not added when escalating with history
+- Fix escalating with history
 - Fix ```status``` after escalation
 
 ## [2.9.8] - 2024-07-15
@@ -17,8 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Prevent an escalation when a ticket is updated
-- Fix escalating with history
-- Fix task not added when escalating with history
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Correction of the task message generated during escalation
+- Fix ```status``` after escalation
 
 ## [2.9.8] - 2024-07-15
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -87,6 +87,7 @@ class PluginEscaladeTicket
                 //disable notification to prevent notification for old AND new group
                 $item->input['_disablenotif'] = true;
                 if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+                    $item->input['_do_not_compute_status'] = true;
                     $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
                 }
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
@@ -100,6 +101,7 @@ class PluginEscaladeTicket
                     if (!isset($old_group_ids[$new_group['items_id']])) {
                         $item->input['_disablenotif'] = true;
                         if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+                            $item->input['_do_not_compute_status'] = true;
                             $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
                         }
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -38,22 +38,6 @@ class PluginEscaladeTicket
 {
     public static function pre_item_update(CommonDBTM $item)
     {
-        //only if update is related to Group assign operation and _from_assignment
-        if (
-            !empty(array_filter(
-                $item->input['_actors']['assign'] ?? [],
-                fn ($actor) => $actor['itemtype'] == 'Group'
-            )) && (
-                isset($item->input['_from_assignment'])
-                && $item->input['_from_assignment']
-            )
-        ) {
-            //handle status behavior
-            if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
-                $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
-            }
-        }
-
         if (isset($input['_itil_assign'])) {
             $item->input['_do_not_compute_status'] = true;
         }
@@ -102,6 +86,9 @@ class PluginEscaladeTicket
             ) {
                 //disable notification to prevent notification for old AND new group
                 $item->input['_disablenotif'] = true;
+                if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+                    $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+                }
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
             } else if (count($old_groups) == count($new_groups)) {
                 $old_group_ids = [];
@@ -112,6 +99,9 @@ class PluginEscaladeTicket
                 foreach ($new_groups as $new_group) {
                     if (!isset($old_group_ids[$new_group['items_id']])) {
                         $item->input['_disablenotif'] = true;
+                        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+                            $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+                        }
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }
                 }


### PR DESCRIPTION
trying to apply a status based on the `_from_assignment` key no longer works

I don't know if this is due to a change in GLPI or in the plugin (it's a pain to debug) but the easiest way is to change the status when we add an entry to the escalation history (which means we actually have an escalation).