### PR TITLE
Fix(Core): take care of mandatory field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Prevent an escalation when a ticket is updated
-- Fix climbing with history
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Redirect users without ticket rights after escalation.
+- Fix private task added when ticket mandatory fields are not filled
 
 ## [2.9.10] - 2024-11-27
 
@@ -32,6 +33,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Prevent an escalation when a ticket is updated
+- Fix climbing with history
 
 ### Changed
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -70,24 +70,28 @@ if (isset($_POST['escalate'])) {
             $_form_object['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
         }
         $updates_ticket = new Ticket();
-        $updates_ticket->update($_POST['ticket_details'] + [
-            '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
-            '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
-            'actortype' => CommonITILActor::ASSIGN,
-            'groups_id' => $group_id,
-            '_form_object' => $_form_object,
-        ]);
-
-        $task = new TicketTask();
-        $task->add([
-            'tickets_id' => $tickets_id,
-            'is_private' => true,
-            'state'      => Planning::INFO,
-            // Sanitize before merging with $_POST['comment'] which is already sanitized
-            'content'    => Sanitizer::sanitize(
-                '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />'
-            ) . $_POST['comment']
-        ]);
+        if (
+            $updates_ticket->update(
+                $_POST['ticket_details'] + [
+                    '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
+                    '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+                    'actortype' => CommonITILActor::ASSIGN,
+                    'groups_id' => $group_id,
+                    '_form_object' => $_form_object,
+                ]
+            )
+        ) {
+            $task = new TicketTask();
+            $task->add([
+                'tickets_id' => $tickets_id,
+                'is_private' => true,
+                'state'      => Planning::INFO,
+                // Sanitize before merging with $_POST['comment'] which is already sanitized
+                'content'    => Sanitizer::sanitize(
+                    '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />'
+                ) . $_POST['comment']
+            ]);
+        }
     }
 
     $track = new Ticket();


### PR DESCRIPTION
Do not add history (task) if ticket update failed (when mandatory fields not filled)