### PR TITLE
Remove second raiseEvent() call to prevent double notification during…

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -404,13 +404,6 @@ class PluginEscaladeTicket
         if ($_SESSION['plugins']['escalade']['config']['remove_group'] == true) {
             self::removeAssignGroups($tickets_id, $groups_id);
         }
-
-        //notified only the last group assigned
-        $ticket = new Ticket();
-        $ticket->getFromDB($tickets_id);
-
-        $event = "assign_group";
-        NotificationEvent::raiseEvent($event, $ticket);
     }
 
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #213 & !34940
- Here is a brief description of what this PR does

During an escalation, when a new group is assigned, the `assign_group` notification is triggered twice.
- The first call is to the `Ticket->update()` function, which calls `post_addItem()`, which in turn triggers a call to `raiseEvent()`.
- The second call is triggered in the `processAfterAddGroup(`) function of the `PluginEscaladeTicket` class.

The problem is solved by deleting the second call above.

