### PR TITLE
Add the group assigned on ticket creation to history

### DIFF
--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -32,6 +32,8 @@ use Glpi\Toolbox\Sanitizer;
 
 include('../../../inc/includes.php');
 
+global $CFG_GLPI;
+
 if (isset($_POST['escalate'])) {
     $group_id = (int)$_POST['groups_id'];
     $tickets_id = (int)$_POST['tickets_id'];
@@ -86,6 +88,8 @@ if (isset($_POST['escalate'])) {
             ) . $_POST['comment']
         ]);
     }
+
+    $track = new Ticket();
 
     if (!$track->can($_POST["tickets_id"], READ)) {
         Session::addMessageAfterRedirect(

--- a/hook.php
+++ b/hook.php
@@ -502,6 +502,26 @@ function plugin_escalade_item_add_ticket($item)
     if ($item instanceof Ticket) {
         unset($_SESSION['plugin_escalade']['skip_hook_add_user']);
         unset($_SESSION['plugin_escalade']['keep_users']);
+        // add first group in history
+        if ($_SESSION['plugins']['escalade']['config']['remove_group']) {
+            if (isset($item->input['_groups_id_assign']) && $item->input['_groups_id_assign']) {
+                $groups = $item->input['_groups_id_assign'];
+                if (is_array($groups)) {
+                    $groups = array_values($groups);
+                    $groups_id = $groups[count($groups) - 1];
+                } else {
+                    $groups_id = $groups;
+                }
+                $group_ticket = new Group_Ticket();
+                $group_ticket->input = [
+                    'id' => $item->getID(),
+                    'groups_id' => $groups_id,
+                    'actortype' => CommonITILActor::ASSIGN,
+                    '_disablenotif' => true
+                ];
+                PluginEscaladeTicket::addHistoryOnAddGroup($group_ticket);
+            }
+        }
     }
 }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -330,7 +330,20 @@ class PluginEscaladeTicket
         $previous_groups_id = 0;
         $counter            = 0;
 
-        if (count($group_ticket->fields) > 0) {
+        // check if group assignment is made during ticket creation
+        $in_add = false;
+        $backtraces   = debug_backtrace();
+        foreach ($backtraces as $backtrace) {
+            if (
+                $backtrace['function'] == "add"
+                && ($backtrace['object'] instanceof CommonITILObject)
+            ) {
+                $in_add = true;
+                break;
+            }
+        }
+
+        if (count($group_ticket->fields) > 0 && !$in_add) {
             $previous_groups_id = $group_ticket->fields['groups_id'];
 
             $last_history_groups = PluginEscaladeHistory::getLastHistoryForTicketAndGroup($tickets_id, $groups_id, $previous_groups_id);
@@ -347,17 +360,9 @@ class PluginEscaladeTicket
             'counter'            => $counter
         ]);
 
-        // check if group assignment is made during ticket creation
         // in this case, skip following steps as it cannot be considered as a group escalation
-        $backtraces   = debug_backtrace();
-        foreach ($backtraces as $backtrace) {
-            if (
-                $backtrace['function'] == "add"
-                && ($backtrace['object'] instanceof CommonITILObject)
-            ) {
-                return;
-                break;
-            }
+        if ($in_add) {
+            return;
         }
 
         //remove old user(s) (pass if user added by new ticket)


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.

## Description

Use hook item_add to create first record in glpi_plugin_escalade_histories when a group is assigned at creation.
Related to [issues 261](https://github.com/pluginsGLPI/escalade/issues/261).

