### PR TITLE
Remove user deletion when we add more than one user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix accidental deletion of new users when adding to a ticket
 - Redirect users without ticket rights after escalation.
 
 ## [2.9.10] - 2024-11-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- Fix accidental deletion of new users when adding to a ticket
+- Ensure that when several technicians are assigned, they are treated correctly during the escalation.
 - Redirect users without ticket rights after escalation.
 
 ## [2.9.10] - 2024-11-27

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -29,7 +29,6 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
-use Symfony\Component\VarDumper\VarDumper;
 
 if (!defined('GLPI_ROOT')) {
     die("Sorry. You can't access directly to this file");

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -108,6 +108,8 @@ class PluginEscaladeTicket
                     }
                 }
             }
+
+            self::removeAssignUsers($item);
             return $item;
         }
     }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -29,6 +29,7 @@
  */
 
 use Glpi\Application\View\TemplateRenderer;
+use Symfony\Component\VarDumper\VarDumper;
 
 if (!defined('GLPI_ROOT')) {
     die("Sorry. You can't access directly to this file");
@@ -589,7 +590,6 @@ class PluginEscaladeTicket
 
             //delete user
             $ticket_user->delete(['id' => $id]);
-
             if (isset($item->input['_actors'])) {
                 foreach ($item->input['_actors'][$types[$type]] as $key => $actor) {
                     if (

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -622,7 +622,6 @@ class PluginEscaladeTicket
         $ticket->getFromDB($tickets_id);
         $groups_id = [];
 
-        self::removeAssignUsers($ticket, $users_id, $type);
 
         // == Add user groups on modification ==
         //check this plugin config

--- a/tests/units/UserEscalationTest.php
+++ b/tests/units/UserEscalationTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Escalade plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Escalade.
+ *
+ * Escalade is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Escalade is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Escalade. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2015-2023 by Escalade plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/escalade
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Escalade\Tests\Units;
+
+use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
+use PluginEscaladeConfig;
+
+final class UserEscalationTest extends EscaladeTestCase
+{
+    public function testTaskGroupEscalation()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = reset($config->find());
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+        $this->assertTrue($config->update([
+            'remove_tech' => 1
+        ] + $conf));
+
+        $user1 = $user2 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $ticket = new \Ticket();
+        $t_id = $ticket->add([
+            'name' => 'Task User change Escalation Test',
+            'content' => '',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+
+        $ticket_user = new \Ticket_User();
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+
+        // Update ticket with just one group
+        $this->assertTrue($ticket->update(
+            [
+                'id' => $t_id,
+                '_actors' => [
+                    'assign' => [
+                        [
+                            'items_id' => $user1->getID(),
+                            'itemtype' => 'User'
+                        ],
+                        [
+                            'items_id' => $user2->getID(),
+                            'itemtype' => 'User'
+                        ]
+                    ],
+                ],
+            ]
+        ));
+
+        $ticket_user = new \Ticket_User();
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35657
- Here is a brief description of what this PR does

When we try to add several technicians to a ticket with the escalation plugin enabled and the Remove technician(s) on escalation option active, only 1 is assigned. 

## Screenshots (if appropriate):
![Screencast-from-18-12-2024-15_03_20](https://github.com/user-attachments/assets/280d0d33-f937-4520-9787-2f449d092949)

