### PR TITLE
fix: rename $_SESSION key from 'plugins' to 'glpi_plugins'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix private task added when ticket mandatory fields are not filled
 - Remove redundant notifications
 - Fixed assignment of requester group to ticket
+- fix: rename $_SESSION key from 'plugins' to 'glpi_plugins'
 
 ## [2.9.10] - 2024-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fix private task added when ticket mandatory fields are not filled
 - Remove redundant notifications
 - Fixed assignment of requester group to ticket
-- fix: rename $_SESSION key from 'plugins' to 'glpi_plugins'
+- Ensure plugin works seamlessly in external contexts (e.g., from plugins)
 
 ## [2.9.10] - 2024-11-27
 

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -401,4 +401,30 @@ class PluginEscaladeConfig extends CommonDBTM
             'rand' => $rand,
         ]);
     }
+
+    public static function getConfig($field = false)
+    {
+        $config = new self();
+        $config->getFromDB(1);
+        unset($config->fields['id']);
+
+        if (
+            isset($_SESSION['glpiID'])
+            && isset($config->fields['use_filter_assign_group'])
+            && $config->fields['use_filter_assign_group']
+        ) {
+            $user = new PluginEscaladeUser();
+            if ($user->getFromDBByCrit(['users_id' => $_SESSION['glpiID']])) {
+               //if a bypass is defined for user
+                if ($user->fields['use_filter_assign_group']) {
+                    $config->fields['use_filter_assign_group'] = 0;
+                }
+            }
+        }
+
+        if ($field === false) {
+            return $config->fields;
+        }
+        return $config->fields[$field];
+    }
 }

--- a/inc/config.class.php
+++ b/inc/config.class.php
@@ -380,7 +380,7 @@ class PluginEscaladeConfig extends CommonDBTM
             }
         }
 
-        $_SESSION['plugins']['escalade']['config'] = $config->fields;
+        $_SESSION['glpi_plugins']['escalade']['config'] = $config->fields;
     }
 
     public static function dropdownGenericStatus($itemtype, $name, $rand, $value = CommonITILObject::INCOMING)
@@ -400,31 +400,5 @@ class PluginEscaladeConfig extends CommonDBTM
             'width' => '80%',
             'rand' => $rand,
         ]);
-    }
-
-    public static function getConfig($field = false)
-    {
-        $config = new self();
-        $config->getFromDB(1);
-        unset($config->fields['id']);
-
-        if (
-            isset($_SESSION['glpiID'])
-            && isset($config->fields['use_filter_assign_group'])
-            && $config->fields['use_filter_assign_group']
-        ) {
-            $user = new PluginEscaladeUser();
-            if ($user->getFromDBByCrit(['users_id' => $_SESSION['glpiID']])) {
-               //if a bypass is defined for user
-                if ($user->fields['use_filter_assign_group']) {
-                    $config->fields['use_filter_assign_group'] = 0;
-                }
-            }
-        }
-
-        if ($field === false) {
-            return $config->fields;
-        }
-        return $config->fields[$field];
     }
 }

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -85,7 +85,7 @@ class PluginEscaladeHistory extends CommonDBTM
         global $CFG_GLPI;
 
         $filter_groups_id = [];
-        if (PluginEscaladeConfig::getConfig('use_filter_assign_group')) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['use_filter_assign_group']) {
             $groups_groups = new PluginEscaladeGroup_Group();
              $filter_groups_id = $groups_groups->getGroups($tickets_id);
             $use_filter_assign_group = true;

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -85,7 +85,7 @@ class PluginEscaladeHistory extends CommonDBTM
         global $CFG_GLPI;
 
         $filter_groups_id = [];
-        if ($_SESSION['plugins']['escalade']['config']['use_filter_assign_group']) {
+        if (PluginEscaladeConfig::getConfig('use_filter_assign_group')) {
             $groups_groups = new PluginEscaladeGroup_Group();
              $filter_groups_id = $groups_groups->getGroups($tickets_id);
             $use_filter_assign_group = true;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -285,7 +285,7 @@ class PluginEscaladeTicket
             }
 
             //update status
-            if (PluginEscaladeConfig::getConfig('ticket_last_status')) {
+            if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
                 $item->update([
                     'id' => $tickets_id,
                     'status' => PluginEscaladeConfig::getConfig('ticket_last_status')

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -42,7 +42,7 @@ class PluginEscaladeTicket
         if (isset($item->input['_itil_assign'])) {
             $item->input['_do_not_compute_status'] = true;
         }
-        $config = $_SESSION['plugins']['escalade']['config'];
+        $config = PluginEscaladeConfig::getConfig();
         $old_groups = [];
 
         // Get actual actors for the ticket
@@ -87,9 +87,9 @@ class PluginEscaladeTicket
             ) {
                 //disable notification to prevent notification for old AND new group
                 $item->input['_disablenotif'] = true;
-                if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+                if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
                     $item->input['_do_not_compute_status'] = true;
-                    $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+                    $item->input['status'] = PluginEscaladeConfig::getConfig('ticket_last_status');
                 }
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
             } else if (count($old_groups) == count($new_groups)) {
@@ -101,9 +101,9 @@ class PluginEscaladeTicket
                 foreach ($new_groups as $new_group) {
                     if (!isset($old_group_ids[$new_group['items_id']])) {
                         $item->input['_disablenotif'] = true;
-                        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+                        if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
                             $item->input['_do_not_compute_status'] = true;
-                            $item->input['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+                            $item->input['status'] = PluginEscaladeConfig::getConfig('ticket_last_status');
                         }
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }
@@ -123,7 +123,7 @@ class PluginEscaladeTicket
     public static function item_update(CommonDBTM $item)
     {
 
-        if ($_SESSION['plugins']['escalade']['config']['remove_group']) {
+        if (PluginEscaladeConfig::getConfig('remove_group')) {
             //solve ticket
             if (isset($item->input['status']) && $item->input['status'] == CommonITILObject::SOLVED) {
                 self::AssignFirstGroupOnSolve($item);
@@ -171,8 +171,8 @@ class PluginEscaladeTicket
     public static function AssignFirstGroupOnSolve(CommonDBTM $item)
     {
         if (
-            $_SESSION['plugins']['escalade']['config']['remove_group']
-            && $_SESSION['plugins']['escalade']['config']['solve_return_group']
+            PluginEscaladeConfig::getConfig('remove_group')
+            && PluginEscaladeConfig::getConfig('solve_return_group')
         ) {
             $tickets_id = $item->fields['id'];
 
@@ -206,7 +206,7 @@ class PluginEscaladeTicket
             }
 
             //add a task to inform the escalation
-            if ($_SESSION['plugins']['escalade']['config']['task_history']) {
+            if (PluginEscaladeConfig::getConfig('task_history')) {
                 $group = new Group();
                 $group->getFromDB($first_history['groups_id']);
                 $task = new TicketTask();
@@ -235,8 +235,8 @@ class PluginEscaladeTicket
         }
 
         if (
-            $_SESSION['plugins']['escalade']['config']['remove_group']
-            && $_SESSION['plugins']['escalade']['config']['solve_return_group']
+            PluginEscaladeConfig::getConfig('remove_group')
+            && PluginEscaladeConfig::getConfig('solve_return_group')
         ) {
             $tickets_id = $item->fields['id'];
 
@@ -271,7 +271,7 @@ class PluginEscaladeTicket
             ]);
 
             //add a task to inform the escalation
-            if ($_SESSION['plugins']['escalade']['config']['task_history']) {
+            if (PluginEscaladeConfig::getConfig('task_history')) {
                 $group = new Group();
                 $group->getFromDB($rejected_history['groups_id']);
                 $task = new TicketTask();
@@ -285,10 +285,10 @@ class PluginEscaladeTicket
             }
 
             //update status
-            if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+            if (PluginEscaladeConfig::getConfig('ticket_last_status')) {
                 $item->update([
                     'id' => $tickets_id,
-                    'status' => $_SESSION['plugins']['escalade']['config']['ticket_last_status']
+                    'status' => PluginEscaladeConfig::getConfig('ticket_last_status')
                 ]);
             }
         }
@@ -305,7 +305,7 @@ class PluginEscaladeTicket
         /** @var DBmysql $DB */
         global $DB;
 
-        if ($_SESSION['plugins']['escalade']['config']['remove_group'] == false) {
+        if (PluginEscaladeConfig::getConfig('remove_group') == false) {
             return true;
         }
 
@@ -371,7 +371,7 @@ class PluginEscaladeTicket
             return $item;
         }
         if (
-            $_SESSION['plugins']['escalade']['config']['task_history']
+            PluginEscaladeConfig::getConfig('task_history')
             && !($item->input['_plugin_escalade_no_history'] ?? false)
         ) {
             $group = new Group();
@@ -386,11 +386,11 @@ class PluginEscaladeTicket
             ]);
         }
 
-        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+        if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
             $ticket = new Ticket();
             $ticket->update([
                 'id'     => $tickets_id,
-                'status' => $_SESSION['plugins']['escalade']['config']['ticket_last_status']
+                'status' => PluginEscaladeConfig::getConfig('ticket_last_status')
             ]);
         }
 
@@ -403,7 +403,7 @@ class PluginEscaladeTicket
         $groups_id = $item->fields['groups_id'];
 
         //remove old groups (keep last assigned)
-        if ($_SESSION['plugins']['escalade']['config']['remove_group'] == true) {
+        if (PluginEscaladeConfig::getConfig('remove_group') == true) {
             self::removeAssignGroups($tickets_id, $groups_id);
         }
     }
@@ -431,8 +431,8 @@ class PluginEscaladeTicket
 
         //check this plugin config
         if (
-            $_SESSION['plugins']['escalade']['config']['use_assign_user_group'] == 0
-            || $_SESSION['plugins']['escalade']['config']['use_assign_user_group_creation'] == 0
+            PluginEscaladeConfig::getConfig('use_assign_user_group') == 0
+            || PluginEscaladeConfig::getConfig('use_assign_user_group_creation') == 0
         ) {
             return false;
         }
@@ -443,7 +443,7 @@ class PluginEscaladeTicket
             && (!isset($ticket->input['_groups_id_assign'])
                 || empty($ticket->input['_groups_id_assign']))
         ) {
-            if ($_SESSION['plugins']['escalade']['config']['use_assign_user_group'] == 1) {
+            if (PluginEscaladeConfig::getConfig('use_assign_user_group') == 1) {
                 // First group
                 $ticket->input['_groups_id_assign']
                     = PluginEscaladeUser::getTechnicianGroup(
@@ -563,8 +563,8 @@ class PluginEscaladeTicket
     public static function removeAssignUsers($item, $keep_users_id = false, $type = CommonITILActor::ASSIGN)
     {
         if (
-            $_SESSION['plugins']['escalade']['config']['remove_tech'] == false
-            && $_SESSION['plugins']['escalade']['config']['remove_requester'] == false
+            PluginEscaladeConfig::getConfig('remove_tech') == false
+            && PluginEscaladeConfig::getConfig('remove_requester') == false
         ) {
             return;
         }
@@ -649,7 +649,7 @@ class PluginEscaladeTicket
             return true;
         }
 
-        if ($_SESSION['plugins']['escalade']['config']['use_assign_user_group'] == 1) {
+        if (PluginEscaladeConfig::getConfig('use_assign_user_group') == 1) {
             // First group
             $groups_id = PluginEscaladeUser::getTechnicianGroup(
                 $ticket->fields['entities_id'],
@@ -689,7 +689,7 @@ class PluginEscaladeTicket
                 'type'       => CommonITILActor::ASSIGN
             ]);
         } else {
-            if ($_SESSION['plugins']['escalade']['config']['remove_tech']) {
+            if (PluginEscaladeConfig::getConfig('remove_tech')) {
                 self::removeAssignGroups($tickets_id);
             }
         }
@@ -711,7 +711,7 @@ class PluginEscaladeTicket
      */
     public static function linkedTickets(CommonDBTM $ticket, $status = CommonITILObject::SOLVED)
     {
-        if ($_SESSION['plugins']['escalade']['config']['close_linkedtickets']) {
+        if (PluginEscaladeConfig::getConfig('close_linkedtickets')) {
             $input = [
                 'status' => $status
             ];
@@ -756,7 +756,7 @@ class PluginEscaladeTicket
         //category group
         if (
             !empty($category->fields['groups_id'])
-            && $_SESSION['plugins']['escalade']['config']['reassign_group_from_cat']
+            && PluginEscaladeConfig::getConfig('reassign_group_from_cat')
         ) {
             $group_ticket = new Group_Ticket();
 
@@ -771,7 +771,7 @@ class PluginEscaladeTicket
                 //add group to ticket
                 $group_ticket->add($group_condition);
                 //remove old group if needed
-                if ($_SESSION['plugins']['escalade']['config']['remove_group']) {
+                if (PluginEscaladeConfig::getConfig('remove_group')) {
                     if (isset($item->input['_groups_id_assign'])) {
                         foreach ($item->input['_groups_id_assign'] as $idActor => $actor) {
                             unset($item->input['_groups_id_assign'][$idActor]);
@@ -786,7 +786,7 @@ class PluginEscaladeTicket
         //category user
         if (
             !empty($category->fields['users_id'])
-            && $_SESSION['plugins']['escalade']['config']['reassign_tech_from_cat']
+            && PluginEscaladeConfig::getConfig('reassign_tech_from_cat')
         ) {
             $ticket_user = new Ticket_User();
 
@@ -801,7 +801,7 @@ class PluginEscaladeTicket
                 //add user to ticket
                 $ticket_user->add($user_condition);
                 //remove old tech if needed
-                if ($_SESSION['plugins']['escalade']['config']['remove_tech']) {
+                if (PluginEscaladeConfig::getConfig('remove_tech')) {
                     if (isset($item->input['_users_id_assign'])) {
                         foreach ($item->input['_users_id_assign'] as $idActor => $actor) {
                             unset($item->input['_users_id_assign'][$idActor]);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -42,7 +42,7 @@ class PluginEscaladeTicket
         if (isset($item->input['_itil_assign'])) {
             $item->input['_do_not_compute_status'] = true;
         }
-        $config = PluginEscaladeConfig::getConfig();
+        $config = $_SESSION['glpi_plugins']['escalade']['config'];
         $old_groups = [];
 
         // Get actual actors for the ticket
@@ -87,9 +87,9 @@ class PluginEscaladeTicket
             ) {
                 //disable notification to prevent notification for old AND new group
                 $item->input['_disablenotif'] = true;
-                if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
+                if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != -1) {
                     $item->input['_do_not_compute_status'] = true;
-                    $item->input['status'] = PluginEscaladeConfig::getConfig('ticket_last_status');
+                    $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                 }
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
             } else if (count($old_groups) == count($new_groups)) {
@@ -101,9 +101,9 @@ class PluginEscaladeTicket
                 foreach ($new_groups as $new_group) {
                     if (!isset($old_group_ids[$new_group['items_id']])) {
                         $item->input['_disablenotif'] = true;
-                        if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
+                        if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != -1) {
                             $item->input['_do_not_compute_status'] = true;
-                            $item->input['status'] = PluginEscaladeConfig::getConfig('ticket_last_status');
+                            $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                         }
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }
@@ -123,7 +123,7 @@ class PluginEscaladeTicket
     public static function item_update(CommonDBTM $item)
     {
 
-        if (PluginEscaladeConfig::getConfig('remove_group')) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group']) {
             //solve ticket
             if (isset($item->input['status']) && $item->input['status'] == CommonITILObject::SOLVED) {
                 self::AssignFirstGroupOnSolve($item);
@@ -171,8 +171,8 @@ class PluginEscaladeTicket
     public static function AssignFirstGroupOnSolve(CommonDBTM $item)
     {
         if (
-            PluginEscaladeConfig::getConfig('remove_group')
-            && PluginEscaladeConfig::getConfig('solve_return_group')
+            $_SESSION['glpi_plugins']['escalade']['config']['remove_group']
+            && $_SESSION['glpi_plugins']['escalade']['config']['solve_return_group']
         ) {
             $tickets_id = $item->fields['id'];
 
@@ -206,7 +206,7 @@ class PluginEscaladeTicket
             }
 
             //add a task to inform the escalation
-            if (PluginEscaladeConfig::getConfig('task_history')) {
+            if ($_SESSION['glpi_plugins']['escalade']['config']['task_history']) {
                 $group = new Group();
                 $group->getFromDB($first_history['groups_id']);
                 $task = new TicketTask();
@@ -235,8 +235,8 @@ class PluginEscaladeTicket
         }
 
         if (
-            PluginEscaladeConfig::getConfig('remove_group')
-            && PluginEscaladeConfig::getConfig('solve_return_group')
+            $_SESSION['glpi_plugins']['escalade']['config']['remove_group']
+            && $_SESSION['glpi_plugins']['escalade']['config']['solve_return_group']
         ) {
             $tickets_id = $item->fields['id'];
 
@@ -271,7 +271,7 @@ class PluginEscaladeTicket
             ]);
 
             //add a task to inform the escalation
-            if (PluginEscaladeConfig::getConfig('task_history')) {
+            if ($_SESSION['glpi_plugins']['escalade']['config']['task_history']) {
                 $group = new Group();
                 $group->getFromDB($rejected_history['groups_id']);
                 $task = new TicketTask();
@@ -285,10 +285,10 @@ class PluginEscaladeTicket
             }
 
             //update status
-            if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
+            if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != -1) {
                 $item->update([
                     'id' => $tickets_id,
-                    'status' => PluginEscaladeConfig::getConfig('ticket_last_status')
+                    'status' => $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status']
                 ]);
             }
         }
@@ -305,7 +305,7 @@ class PluginEscaladeTicket
         /** @var DBmysql $DB */
         global $DB;
 
-        if (PluginEscaladeConfig::getConfig('remove_group') == false) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == false) {
             return true;
         }
 
@@ -371,7 +371,7 @@ class PluginEscaladeTicket
             return $item;
         }
         if (
-            PluginEscaladeConfig::getConfig('task_history')
+            $_SESSION['glpi_plugins']['escalade']['config']['task_history']
             && !($item->input['_plugin_escalade_no_history'] ?? false)
         ) {
             $group = new Group();
@@ -386,11 +386,11 @@ class PluginEscaladeTicket
             ]);
         }
 
-        if (PluginEscaladeConfig::getConfig('ticket_last_status') != -1) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != -1) {
             $ticket = new Ticket();
             $ticket->update([
                 'id'     => $tickets_id,
-                'status' => PluginEscaladeConfig::getConfig('ticket_last_status')
+                'status' => $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status']
             ]);
         }
 
@@ -403,7 +403,7 @@ class PluginEscaladeTicket
         $groups_id = $item->fields['groups_id'];
 
         //remove old groups (keep last assigned)
-        if (PluginEscaladeConfig::getConfig('remove_group') == true) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
             self::removeAssignGroups($tickets_id, $groups_id);
         }
     }
@@ -431,8 +431,8 @@ class PluginEscaladeTicket
 
         //check this plugin config
         if (
-            PluginEscaladeConfig::getConfig('use_assign_user_group') == 0
-            || PluginEscaladeConfig::getConfig('use_assign_user_group_creation') == 0
+            $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] == 0
+            || $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] == 0
         ) {
             return false;
         }
@@ -443,7 +443,7 @@ class PluginEscaladeTicket
             && (!isset($ticket->input['_groups_id_assign'])
                 || empty($ticket->input['_groups_id_assign']))
         ) {
-            if (PluginEscaladeConfig::getConfig('use_assign_user_group') == 1) {
+            if ($_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] == 1) {
                 // First group
                 $ticket->input['_groups_id_assign']
                     = PluginEscaladeUser::getTechnicianGroup(
@@ -563,15 +563,15 @@ class PluginEscaladeTicket
     public static function removeAssignUsers($item, $keep_users_id = false, $type = CommonITILActor::ASSIGN)
     {
         if (
-            PluginEscaladeConfig::getConfig('remove_tech') == false
-            && PluginEscaladeConfig::getConfig('remove_requester') == false
+            $_SESSION['glpi_plugins']['escalade']['config']['remove_tech'] == false
+            && $_SESSION['glpi_plugins']['escalade']['config']['remove_requester'] == false
         ) {
             return;
         }
-        if ($type == CommonITILActor::ASSIGN && !$_SESSION['plugins']['escalade']['config']['remove_tech']) {
+        if ($type == CommonITILActor::ASSIGN && !$_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
             return;
         }
-        if ($type == CommonITILActor::REQUESTER && !$_SESSION['plugins']['escalade']['config']['remove_requester']) {
+        if ($type == CommonITILActor::REQUESTER && !$_SESSION['glpi_plugins']['escalade']['config']['remove_requester']) {
             return;
         }
 
@@ -642,14 +642,14 @@ class PluginEscaladeTicket
         // == Add user groups on modification ==
         //check this plugin config
         if (
-            $_SESSION['plugins']['escalade']['config']['use_assign_user_group'] == 0
-            || $_SESSION['plugins']['escalade']['config']['use_assign_user_group_modification'] == 0
+            $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] == 0
+            || $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_modification'] == 0
             || $type != CommonITILActor::ASSIGN
         ) {
             return true;
         }
 
-        if (PluginEscaladeConfig::getConfig('use_assign_user_group') == 1) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] == 1) {
             // First group
             $groups_id = PluginEscaladeUser::getTechnicianGroup(
                 $ticket->fields['entities_id'],
@@ -689,7 +689,7 @@ class PluginEscaladeTicket
                 'type'       => CommonITILActor::ASSIGN
             ]);
         } else {
-            if (PluginEscaladeConfig::getConfig('remove_tech')) {
+            if ($_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
                 self::removeAssignGroups($tickets_id);
             }
         }
@@ -711,7 +711,7 @@ class PluginEscaladeTicket
      */
     public static function linkedTickets(CommonDBTM $ticket, $status = CommonITILObject::SOLVED)
     {
-        if (PluginEscaladeConfig::getConfig('close_linkedtickets')) {
+        if ($_SESSION['glpi_plugins']['escalade']['config']['close_linkedtickets']) {
             $input = [
                 'status' => $status
             ];
@@ -756,7 +756,7 @@ class PluginEscaladeTicket
         //category group
         if (
             !empty($category->fields['groups_id'])
-            && PluginEscaladeConfig::getConfig('reassign_group_from_cat')
+            && $_SESSION['glpi_plugins']['escalade']['config']['reassign_group_from_cat']
         ) {
             $group_ticket = new Group_Ticket();
 
@@ -771,7 +771,7 @@ class PluginEscaladeTicket
                 //add group to ticket
                 $group_ticket->add($group_condition);
                 //remove old group if needed
-                if (PluginEscaladeConfig::getConfig('remove_group')) {
+                if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group']) {
                     if (isset($item->input['_groups_id_assign'])) {
                         foreach ($item->input['_groups_id_assign'] as $idActor => $actor) {
                             unset($item->input['_groups_id_assign'][$idActor]);
@@ -786,7 +786,7 @@ class PluginEscaladeTicket
         //category user
         if (
             !empty($category->fields['users_id'])
-            && PluginEscaladeConfig::getConfig('reassign_tech_from_cat')
+            && $_SESSION['glpi_plugins']['escalade']['config']['reassign_tech_from_cat']
         ) {
             $ticket_user = new Ticket_User();
 
@@ -801,7 +801,7 @@ class PluginEscaladeTicket
                 //add user to ticket
                 $ticket_user->add($user_condition);
                 //remove old tech if needed
-                if (PluginEscaladeConfig::getConfig('remove_tech')) {
+                if ($_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
                     if (isset($item->input['_users_id_assign'])) {
                         foreach ($item->input['_users_id_assign'] as $idActor => $actor) {
                             unset($item->input['_users_id_assign'][$idActor]);

--- a/js/remove_btn.js.php
+++ b/js/remove_btn.js.php
@@ -36,7 +36,7 @@ header("Content-type: application/javascript");
 //not executed in self-service interface & right verification
 if ($_SESSION['glpiactiveprofile']['interface'] == "central") {
     $locale_actor = __('Actor');
-    $esc_config = PluginEscaladeConfig::getConfig();
+    $esc_config = $_SESSION['glpi_plugins']['escalade']['config'];
 
     $remove_delete_requester_user_btn = "true";
     if (

--- a/js/remove_btn.js.php
+++ b/js/remove_btn.js.php
@@ -36,7 +36,7 @@ header("Content-type: application/javascript");
 //not executed in self-service interface & right verification
 if ($_SESSION['glpiactiveprofile']['interface'] == "central") {
     $locale_actor = __('Actor');
-    $esc_config = $_SESSION['plugins']['escalade']['config'];
+    $esc_config = PluginEscaladeConfig::getConfig();
 
     $remove_delete_requester_user_btn = "true";
     if (

--- a/setup.php
+++ b/setup.php
@@ -59,10 +59,11 @@ function plugin_init_escalade()
     if ((isset($_SESSION['glpiID']) || isCommandLine()) && Plugin::isPluginActive('escalade')) {
        //load config in session
         if ($DB->tableExists("glpi_plugin_escalade_configs")) {
+            PluginEscaladeConfig::loadInSession();
 
            // == Load js scripts ==
-            if (is_array(PluginEscaladeConfig::getConfig())) {
-                $escalade_config = PluginEscaladeConfig::getConfig();
+            if (isset($_SESSION['glpi_plugins']['escalade']['config'])) {
+                $escalade_config = $_SESSION['glpi_plugins']['escalade']['config'];
 
                 $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/function.js';
 

--- a/setup.php
+++ b/setup.php
@@ -59,11 +59,10 @@ function plugin_init_escalade()
     if ((isset($_SESSION['glpiID']) || isCommandLine()) && Plugin::isPluginActive('escalade')) {
        //load config in session
         if ($DB->tableExists("glpi_plugin_escalade_configs")) {
-            PluginEscaladeConfig::loadInSession();
 
            // == Load js scripts ==
-            if (isset($_SESSION['plugins']['escalade']['config'])) {
-                $escalade_config = $_SESSION['plugins']['escalade']['config'];
+            if (is_array(PluginEscaladeConfig::getConfig())) {
+                $escalade_config = PluginEscaladeConfig::getConfig();
 
                 $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/function.js';
 

--- a/setup.php
+++ b/setup.php
@@ -56,12 +56,11 @@ function plugin_init_escalade()
 
     $PLUGIN_HOOKS['csrf_compliant']['escalade'] = true;
     if (Plugin::isPluginActive('escalade')) {
-        if (isset($_SESSION['glpiID']) || isCommandLine()) {
+        if ($DB->tableExists("glpi_plugin_escalade_configs")) {
             //load config in session
-            if ($DB->tableExists("glpi_plugin_escalade_configs")) {
-                PluginEscaladeConfig::loadInSession();
-
-            // == Load js scripts ==
+            PluginEscaladeConfig::loadInSession();
+            if (isset($_SESSION['glpiID']) || isCommandLine()) {
+                // == Load js scripts ==
                 if (isset($_SESSION['glpi_plugins']['escalade']['config'])) {
                     $escalade_config = $_SESSION['glpi_plugins']['escalade']['config'];
 

--- a/setup.php
+++ b/setup.php
@@ -55,64 +55,65 @@ function plugin_init_escalade()
     global $PLUGIN_HOOKS, $DB;
 
     $PLUGIN_HOOKS['csrf_compliant']['escalade'] = true;
+    if (Plugin::isPluginActive('escalade')) {
+        if (isset($_SESSION['glpiID']) || isCommandLine()) {
+            //load config in session
+            if ($DB->tableExists("glpi_plugin_escalade_configs")) {
+                PluginEscaladeConfig::loadInSession();
 
-    if ((isset($_SESSION['glpiID']) || isCommandLine()) && Plugin::isPluginActive('escalade')) {
-       //load config in session
-        if ($DB->tableExists("glpi_plugin_escalade_configs")) {
-            PluginEscaladeConfig::loadInSession();
+            // == Load js scripts ==
+                if (isset($_SESSION['glpi_plugins']['escalade']['config'])) {
+                    $escalade_config = $_SESSION['glpi_plugins']['escalade']['config'];
 
-           // == Load js scripts ==
-            if (isset($_SESSION['glpi_plugins']['escalade']['config'])) {
-                $escalade_config = $_SESSION['glpi_plugins']['escalade']['config'];
+                    $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/function.js';
 
-                $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/function.js';
-
-                // on central page
-                if (strpos($_SERVER['REQUEST_URI'] ?? '', "central.php") !== false) {
-                   //history and climb feature
-                    if ($escalade_config['show_history']) {
-                        $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/central.js.php';
+                    // on central page
+                    if (strpos($_SERVER['REQUEST_URI'] ?? '', "central.php") !== false) {
+                    //history and climb feature
+                        if ($escalade_config['show_history']) {
+                            $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/central.js.php';
+                        }
                     }
-                }
 
-                // on ticket page (in edition)
-                if (
-                    (strpos($_SERVER['REQUEST_URI'] ?? '', "ticket.form.php") !== false
-                    || strpos($_SERVER['REQUEST_URI'] ?? '', "problem.form.php") !== false
-                    || strpos($_SERVER['REQUEST_URI'] ?? '', "change.form.php") !== false) && isset($_GET['id'])
-                ) {
+                    // on ticket page (in edition)
                     if (
-                        !$escalade_config['remove_delete_requester_user_btn']
-                        || !$escalade_config['remove_delete_watcher_user_btn']
-                        || !$escalade_config['remove_delete_assign_user_btn']
-                        || !$escalade_config['remove_delete_requester_group_btn']
-                        || !$escalade_config['remove_delete_watcher_group_btn']
-                        || !$escalade_config['remove_delete_assign_group_btn']
-                        || !$escalade_config['remove_delete_assign_supplier_btn']
+                        (strpos($_SERVER['REQUEST_URI'] ?? '', "ticket.form.php") !== false
+                        || strpos($_SERVER['REQUEST_URI'] ?? '', "problem.form.php") !== false
+                        || strpos($_SERVER['REQUEST_URI'] ?? '', "change.form.php") !== false) && isset($_GET['id'])
                     ) {
-                      //remove btn feature
-                        $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/remove_btn.js.php';
+                        if (
+                            !$escalade_config['remove_delete_requester_user_btn']
+                            || !$escalade_config['remove_delete_watcher_user_btn']
+                            || !$escalade_config['remove_delete_assign_user_btn']
+                            || !$escalade_config['remove_delete_requester_group_btn']
+                            || !$escalade_config['remove_delete_watcher_group_btn']
+                            || !$escalade_config['remove_delete_assign_group_btn']
+                            || !$escalade_config['remove_delete_assign_supplier_btn']
+                        ) {
+                        //remove btn feature
+                            $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/remove_btn.js.php';
+                        }
                     }
+
+                    // on ticket page (in edition)
+                    if (
+                        strpos($_SERVER['REQUEST_URI'] ?? '', "ticket.form.php") !== false
+                        && isset($_GET['id'])
+                    ) {
+                    //history and climb feature
+                        if ($escalade_config['show_history']) {
+                            $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/escalade.js.php';
+                        }
+
+                    //clone ticket feature
+                        if ($escalade_config['cloneandlink_ticket']) {
+                            $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/cloneandlink_ticket.js.php';
+                        }
+                    }
+
+                    Plugin::registerClass('PluginEscaladeGroup_Group', ['addtabon' => 'Group']);
+                    Plugin::registerClass('PluginEscaladeUser', ['addtabon' => ['User']]);
                 }
-
-                // on ticket page (in edition)
-                if (
-                    strpos($_SERVER['REQUEST_URI'] ?? '', "ticket.form.php") !== false
-                    && isset($_GET['id'])
-                ) {
-                   //history and climb feature
-                    if ($escalade_config['show_history']) {
-                        $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/escalade.js.php';
-                    }
-
-                   //clone ticket feature
-                    if ($escalade_config['cloneandlink_ticket']) {
-                        $PLUGIN_HOOKS['add_javascript']['escalade'][] = 'js/cloneandlink_ticket.js.php';
-                    }
-                }
-
-                Plugin::registerClass('PluginEscaladeGroup_Group', ['addtabon' => 'Group']);
-                Plugin::registerClass('PluginEscaladeUser', ['addtabon' => ['User']]);
             }
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes !35797
- This RP resolves the issue that the configuration of the Escalation module was saved in the $_SESSION with the 'plugins' key while most other plugins use the 'glpi_plugins' key. This posed an issue with, for example, the ApproveByMail plugin. If the user has rules that modify the group if a validation is accepted with ticket rules and he approves a validation with the ApproveByMail plugin, the old group is not deleted even if the configuration "Delete old groups when adding a new" of climb is set to "Yes".

