### PR TITLE
Fix wrong group assign to a ticket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Redirect users without ticket rights after escalation.
 - Fix private task added when ticket mandatory fields are not filled
 - Remove redundant notifications
+- Fixed assignment of requester group to ticket
 
 ## [2.9.10] - 2024-11-27
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -644,6 +644,7 @@ class PluginEscaladeTicket
         if (
             $_SESSION['plugins']['escalade']['config']['use_assign_user_group'] == 0
             || $_SESSION['plugins']['escalade']['config']['use_assign_user_group_modification'] == 0
+            || $type != CommonITILActor::ASSIGN
         ) {
             return true;
         }

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -57,9 +57,31 @@ final class GroupEscalationTest extends EscaladeTestCase
         $user1->getFromDBbyName('glpi');
         $this->assertGreaterThan(0, $user1->getID());
 
+        $group1 = new \Group();
+        $group1_id = $group1->add(['name' => 'Group_1']);
+        $this->assertGreaterThan(0, $group1_id);
+
+        $user_group1 = new \Group_User();
+        $user_group1->add([
+            'users_id' => $user1->getID(),
+            'groups_id' => $group1->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group1->getID());
+
         $user2 = new \User();
         $user2->getFromDBbyName('tech');
         $this->assertGreaterThan(0, $user2->getID());
+
+        $group2 = new \Group();
+        $group2_id = $group2->add(['name' => 'Group_2']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $user_group2 = new \Group_User();
+        $user_group2->add([
+            'users_id' => $user2->getID(),
+            'groups_id' => $group2->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group2->getID());
 
         $ticket = new \Ticket();
         $t_id = $ticket->add([
@@ -104,6 +126,6 @@ final class GroupEscalationTest extends EscaladeTestCase
         $ticket_group2->getFromDBByCrit([
             'tickets_id' => $t_id,
         ]);
-        $this->assertEquals(2, $ticket_group2->fields['groups_id']);
+        $this->assertEquals($group2_id, $ticket_group2->fields['groups_id']);
     }
 }

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Escalade plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Escalade.
+ *
+ * Escalade is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Escalade is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Escalade. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2015-2023 by Escalade plugin team.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/escalade
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Escalade\Tests\Units;
+
+use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
+use Group_User;
+use PluginEscaladeConfig;
+
+final class GroupEscalationTest extends EscaladeTestCase
+{
+    public function testTechGroupAttribution()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+        $this->assertTrue($config->update([
+            'use_assign_user_group'              => 1,
+            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_modification' => 1
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $ticket = new \Ticket();
+        $t_id = $ticket->add([
+            'name' => 'Assign Group Escalation Test',
+            'content' => '',
+            '_actors' => [
+                'requester' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+
+        $ticket_group = new \Group_Ticket();
+        $this->assertEquals(0, count($ticket_group->find(['tickets_id' => $t_id])));
+
+        $this->assertTrue($ticket->update(
+            [
+                'id' => $t_id,
+                '_actors' => [
+                    'requester' => [
+                        [
+                            'items_id' => $user1->getID(),
+                            'itemtype' => 'User'
+                        ]
+                    ],
+                    'assign' => [
+                        [
+                            'items_id' => $user2->getID(),
+                            'itemtype' => 'User'
+                        ]
+                    ],
+                ],
+            ]
+        ));
+
+        $ticket_group2 = new \Group_Ticket();
+        $this->assertEquals(1, count($ticket_group2->find(['tickets_id' => $t_id])));
+
+        $ticket_group2->getFromDBByCrit([
+            'tickets_id' => $t_id,
+        ]);
+        $this->assertEquals(2, $ticket_group2->fields['groups_id']);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !35984
- Here is a brief description of what this PR does
Fixed assignment of requester group to ticket. when the requester was changed, the group assigned to the ticket became that of the requester and not that of the technician.

## Screenshots (if appropriate):
