### PR TITLE
fix: Remove the user when a ticket escalates to a group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Close cloned tickets at the same time` option
 - Fixed `Bypass filtering on the groups assignment` option
 - Rename the option **"Don't change"** to **"Default (not managed by plugin)"** for the **"Ticket status after an escalation"** setting to reduce ambiguity.
+- Remove the user when a ticket escalates to a group with remote_tech option at true
 
 ## [2.9.10] - 2024-11-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Close cloned tickets at the same time` option
 - Fixed `Bypass filtering on the groups assignment` option
 - Rename the option **"Don't change"** to **"Default (not managed by plugin)"** for the **"Ticket status after an escalation"** setting to reduce ambiguity.
-- Remove the user when a ticket escalates to a group with remote_tech option at true
+- Remove the user when a ticket escalates to a group with remote_tech option set to true
 
 ## [2.9.10] - 2024-11-27
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -579,7 +579,11 @@ class PluginEscaladeTicket
             return;
         }
 
-        $tickets_id = $item->input['tickets_id'] ?? $item->fields['tickets_id'];
+        $tickets_id = $item->input['id'] ?? $item->fields['id'];
+
+        if ($item instanceof Group_Ticket) {
+            $tickets_id = $item->input['tickets_id'] ?? $item->fields['tickets_id'];
+        }
 
         $where_keep = [
             'tickets_id' => $tickets_id,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -112,7 +112,9 @@ class PluginEscaladeTicket
                 }
             }
 
-            self::removeAssignUsers($item);
+            if (count($new_groups) > 0) {
+                self::removeAssignUsers($item);
+            }
             return $item;
         }
     }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -93,6 +93,9 @@ class PluginEscaladeTicket
                     $item->input['_do_not_compute_status'] = true;
                     $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                 }
+                if ($config['remove_tech']) {
+                    self::removeAssignUsers($item);
+                }
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
             } elseif (count($old_groups) == count($new_groups)) {
                 $old_group_ids = [];
@@ -110,11 +113,11 @@ class PluginEscaladeTicket
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }
                 }
+                if ($config['remove_tech']) {
+                    self::removeAssignUsers($item);
+                }
             }
 
-            if (count($new_groups) > 0) {
-                self::removeAssignUsers($item);
-            }
             return $item;
         }
     }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -408,6 +408,7 @@ class PluginEscaladeTicket
         if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
             self::removeAssignGroups($tickets_id, $groups_id);
         }
+        //remove old users if remove_tech is enabled
         self::removeAssignUsers($item);
     }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -579,7 +579,7 @@ class PluginEscaladeTicket
             return;
         }
 
-        $tickets_id = $item->input['id'] ?? $item->fields['id'];
+        $tickets_id = $item->input['tickets_id'] ?? $item->fields['tickets_id'];
 
         $where_keep = [
             'tickets_id' => $tickets_id,

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -408,7 +408,7 @@ class PluginEscaladeTicket
         if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
             self::removeAssignGroups($tickets_id, $groups_id);
         }
-        //remove old users if remove_tech is enabled
+        // The config is checked in the function.
         self::removeAssignUsers($item);
     }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -93,9 +93,6 @@ class PluginEscaladeTicket
                     $item->input['_do_not_compute_status'] = true;
                     $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                 }
-                if ($config['remove_tech']) {
-                    self::removeAssignUsers($item);
-                }
                 return PluginEscaladeTicket::addHistoryOnAddGroup($item);
             } elseif (count($old_groups) == count($new_groups)) {
                 $old_group_ids = [];
@@ -113,11 +110,9 @@ class PluginEscaladeTicket
                         return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }
                 }
-                if ($config['remove_tech']) {
-                    self::removeAssignUsers($item);
-                }
             }
 
+            self::removeAssignUsers($item);
             return $item;
         }
     }
@@ -413,6 +408,7 @@ class PluginEscaladeTicket
         if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
             self::removeAssignGroups($tickets_id, $groups_id);
         }
+        self::removeAssignUsers($item);
     }
 
 

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -147,7 +147,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
     }
 
-    public function testUserWithsGroupAttributionWithoutRemoveTechConfig()
+    public function testUserWithsGroupAttributionWithoutRemoveTech()
     {
         $this->login();
 
@@ -159,9 +159,6 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         // Update escalade config
         $this->assertTrue($config->update([
-            'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 1,
             'remove_tech'                        => 0,
         ] + $conf));
 
@@ -211,8 +208,8 @@ final class GroupEscalationTest extends EscaladeTestCase
             '_actors' => [
                 'assign' => [
                     [
-                        'items_id' => $user2->getID(),
-                        'itemtype' => 'User'
+                        'items_id' => $group2->getID(),
+                        'itemtype' => 'Group'
                     ]
                 ],
             ]
@@ -224,7 +221,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
     }
 
-    public function testUserWithsGroupAttributionWithsRemoveTechConfig()
+    public function testUserWithsGroupAttributionWithsRemoveTech()
     {
         $this->login();
 
@@ -236,9 +233,6 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         // Update escalade config
         $this->assertTrue($config->update([
-            'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 1,
             'remove_tech'                        => 1,
         ] + $conf));
 
@@ -288,7 +282,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             '_actors' => [
                 'assign' => [
                     [
-                        'items_id' => $user_group2->getID(),
+                        'items_id' => $group2->getID(),
                         'itemtype' => 'Group'
                     ]
                 ],

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -147,7 +147,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
     }
 
-    public function testUserWithsGroupAttributionWithoutRemoveTech()
+    public function testUserWithsGroupAttributionWithoutRemoveTechConfig()
     {
         $this->login();
 
@@ -210,6 +210,10 @@ final class GroupEscalationTest extends EscaladeTestCase
                     [
                         'items_id' => $group2->getID(),
                         'itemtype' => 'Group'
+                    ],
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
                     ]
                 ],
             ]
@@ -221,7 +225,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
     }
 
-    public function testUserWithsGroupAttributionWithsRemoveTech()
+    public function testUserWithsGroupAttributionWithsRemoveTechConfig()
     {
         $this->login();
 
@@ -284,6 +288,10 @@ final class GroupEscalationTest extends EscaladeTestCase
                     [
                         'items_id' => $group2->getID(),
                         'itemtype' => 'Group'
+                    ],
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
                     ]
                 ],
             ]

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -146,4 +146,158 @@ final class GroupEscalationTest extends EscaladeTestCase
         // Check assign
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
     }
+
+    public function testUserWithsGroupAttributionWithoutRemoveTechConfig()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        // Update escalade config
+        $this->assertTrue($config->update([
+            'use_assign_user_group'              => 1,
+            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_modification' => 1,
+            'remove_tech'                        => 0,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $group2 = new \Group();
+        $group2_id = $group2->add(['name' => 'Group_2']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $user_group2 = new \Group_User();
+        $user_group2->add([
+            'users_id' => $user2->getID(),
+            'groups_id' => $group2->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group2->getID());
+
+        // Create ticket without technician
+        $ticket = new \Ticket();
+        $t_id = $ticket->add([
+            'name' => 'Assign Group Escalation Test',
+            'content' => '',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $t_id);
+
+        $ticket_user = new \Ticket_User();
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+
+        $ticket = new \Ticket();
+        $ticket_update = $ticket->update([
+            'id' => $t_id,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $user2->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertTrue($ticket_update);
+
+        $group_ticket = new \Group_Ticket();
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $t_id])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+    }
+
+    public function testUserWithsGroupAttributionWithsRemoveTechConfig()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        // Update escalade config
+        $this->assertTrue($config->update([
+            'use_assign_user_group'              => 1,
+            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_modification' => 1,
+            'remove_tech'                        => 1,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $group2 = new \Group();
+        $group2_id = $group2->add(['name' => 'Group_2']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $user_group2 = new \Group_User();
+        $user_group2->add([
+            'users_id' => $user2->getID(),
+            'groups_id' => $group2->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group2->getID());
+
+        // Create ticket without technician
+        $ticket = new \Ticket();
+        $t_id = $ticket->add([
+            'name' => 'Assign Group Escalation Test',
+            'content' => '',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $t_id);
+
+        $ticket_user = new \Ticket_User();
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+
+        $ticket = new \Ticket();
+        $ticket_update = $ticket->update([
+            'id' => $t_id,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $user_group2->getID(),
+                        'itemtype' => 'Group'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertTrue($ticket_update);
+
+        $group_ticket = new \Group_Ticket();
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $t_id])));
+        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #36431
- This PR removes users during an escalation to a group if the option "Remove technicians during an escalation" is enabled

## Screenshots (if appropriate):
