### PR TITLE
2.9.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+## [2.9.11] - 2024-03-11
+
 ### Fixed
 
 - Ensure that when several technicians are assigned, they are treated correctly during the escalation.
@@ -18,7 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Close cloned tickets at the same time` option
 - Fixed `Bypass filtering on the groups assignment` option
 - Rename the option **"Don't change"** to **"Default (not managed by plugin)"** for the **"Ticket status after an escalation"** setting to reduce ambiguity.
-- Remove the user when a ticket escalates to a group with remote_tech option set to true
+- Remove the user when a ticket escalates to a group with `remote_tech option` set to `true`
+
+### Security
+
 - Check permissions before displaying group history or escalating access
 
 ## [2.9.10] - 2024-11-27

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.9.11</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.11/glpi-escalade-2.9.11.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.10</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.10/glpi-escalade-2.9.10.tar.bz2</download_url>

--- a/front/popup_histories.php
+++ b/front/popup_histories.php
@@ -35,7 +35,7 @@ if (!Plugin::isPluginActive('escalade')) {
     return;
 }
 
-if (!$_SESSION['glpi_plugins']['escalade']['config']['show_history']){
+if (!$_SESSION['glpi_plugins']['escalade']['config']['show_history']) {
     Html::displayRightError();
 }
 

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.10');
+define('PLUGIN_ESCALADE_VERSION', '2.9.11');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.11] - 2024-03-11

### Fixed

- Ensure that when several technicians are assigned, they are treated correctly during the escalation.
- Redirect users without ticket rights after escalation.
- Fix private task added when ticket mandatory fields are not filled
- Remove redundant notifications
- Fixed assignment of requester group to ticket
- Ensure plugin works seamlessly in external contexts (e.g., from plugins)
- Fixed `Close cloned tickets at the same time` option
- Fixed `Bypass filtering on the groups assignment` option
- Rename the option **"Don't change"** to **"Default (not managed by plugin)"** for the **"Ticket status after an escalation"** setting to reduce ambiguity.
- Remove the user when a ticket escalates to a group with `remote_tech option` set to `true`

### Security

- Check permissions before displaying group history or escalating access