### PR TITLE
fix: Bypass filtering on the groups assignment option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+### Fixed
+
+- Fixed `Bypass filtering on the groups assignment` option
+
 ## [2.9.11] - 2024-03-11
 
 ### Fixed

--- a/hook.php
+++ b/hook.php
@@ -467,8 +467,6 @@ function plugin_escalade_item_add_user($item)
     global $DB;
 
     if ($item instanceof User) {
-        $config = new PluginEscaladeConfig();
-        $config->getFromDB(1);
         $default_value = false;
 
         $query = "INSERT INTO glpi_plugin_escalade_users (`users_id`, `bypass_filter_assign_group`)

--- a/hook.php
+++ b/hook.php
@@ -469,9 +469,9 @@ function plugin_escalade_item_add_user($item)
     if ($item instanceof User) {
         $config = new PluginEscaladeConfig();
         $config->getFromDB(1);
-        $default_value = $config->fields["use_filter_assign_group"];
+        $default_value = false;
 
-        $query = "INSERT INTO glpi_plugin_escalade_users (`users_id`, `use_filter_assign_group`)
+        $query = "INSERT INTO glpi_plugin_escalade_users (`users_id`, `bypass_filter_assign_group`)
                   VALUES (" . $item->getID() . ", $default_value)";
         $DB->doQuery($query);
     }
@@ -579,11 +579,11 @@ function plugin_escalade_getAddSearchOptions($itemtype)
     }
     if ($itemtype == 'User') {
         $sopt[2150]['table']         = 'glpi_plugin_escalade_users';
-        $sopt[2150]['field']         = 'use_filter_assign_group';
+        $sopt[2150]['field']         = 'bypass_filter_assign_group';
         $sopt[2150]['linkfield']     = 'id';
         $sopt[2150]['datatype']      = 'bool';
         $sopt[2150]['searchtype']    = ['equals'];
-        $sopt[2150]['name']          = __("Enable filtering on the groups assignment", 'escalade');
+        $sopt[2150]['name']          = __("Bypass filtering on the groups assignment", 'escalade');
         $sopt[2150]['joinparams']    = [
             'beforejoin'  => [
                 'table'      => 'glpi_plugin_escalade_users',
@@ -601,8 +601,8 @@ function plugin_escalade_MassiveActions($itemtype)
 {
     switch ($itemtype) {
         case 'User':
-            return ['PluginEscaladeUser' . MassiveAction::CLASS_ACTION_SEPARATOR . 'use_filter_assign_group'
-                  => __("Enable filtering on the groups assignment", 'escalade')
+            return ['PluginEscaladeUser' . MassiveAction::CLASS_ACTION_SEPARATOR . 'bypass_filter_assign_group'
+                  => __("Bypass filtering on the groups assignment", 'escalade')
             ];
     }
     return [];

--- a/hook.php
+++ b/hook.php
@@ -467,7 +467,7 @@ function plugin_escalade_item_add_user($item)
     global $DB;
 
     if ($item instanceof User) {
-        $default_value = false;
+        $default_value = 0;
 
         $query = "INSERT INTO glpi_plugin_escalade_users (`users_id`, `bypass_filter_assign_group`)
                   VALUES (" . $item->getID() . ", $default_value)";


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36789
- Here is a brief description of what this PR does

Since https://github.com/pluginsGLPI/escalade/pull/291, when a user is created, this error appears in `sql-error.log`:
```
glpisqllog.ERROR: DBmysql::doQuery() in .../src/DBmysql.php line 395
  *** MySQL query error:
  SQL: INSERT INTO glpi_plugin_escalade_users (`users_id`, `use_filter_assign_group`)
                  VALUES (217023, 0)
  Error: Unknown column 'use_filter_assign_group' in 'field list'
  Backtrace :
  marketplace/escalade/hook.php:476                  DBmysql->doQuery()
  src/Plugin.php:1713                                plugin_escalade_item_add_user()
  src/CommonDBTM.php:1404                            Plugin::doHook()
  src/AuthLDAP.php:2955                              CommonDBTM->add()
  src/Console/Ldap/SynchronizeUsersCommand.php:387   AuthLDAP::ldapImportUserByServerId()
  vendor/symfony/console/Command/Command.php:298     Glpi\Console\Ldap\SynchronizeUsersCommand->execute()
  vendor/symfony/console/Application.php:1040        Symfony\Component\Console\Command\Command->run()
  src/Console/Application.php:286                    Symfony\Component\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:301         Glpi\Console\Application->doRunCommand()
  vendor/symfony/console/Application.php:171         Symfony\Component\Console\Application->doRun()
  bin/console:134                                    Symfony\Component\Console\Application->run()
```

## Screenshots (if appropriate):
