### PR TITLE
fix: status when self-assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+### Fixed
+
+- Calculation of status when a technician self-assigns to a ticket
+
+
 ## [2.9.11] - 2024-03-11
 
 ### Fixed

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -41,7 +41,10 @@ class PluginEscaladeTicket
 
     public static function pre_item_update(CommonDBTM $item)
     {
-        if (isset($item->input['_itil_assign'])) {
+        if (
+            isset($item->input['_itil_assign'])
+            && $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE
+        ) {
             $item->input['_do_not_compute_status'] = true;
         }
         $config = $_SESSION['glpi_plugins']['escalade']['config'];


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36851

Ticket status remains new when a technician self-assigns to the ticket

## Screenshots (if appropriate):
