### PR TITLE
Fix(Core): prevent undefined index on climb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Rename the option **"Don't change"** to **"Default (not managed by plugin)"** for the **"Ticket status after an escalation"** setting to reduce ambiguity.
 - Remove the user when a ticket escalates to a group with remote_tech option set to true
 - Check permissions before displaying group history or escalating access
+- Prevents undefined index `comment` when escalating
 
 ## [2.9.10] - 2024-11-27
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -516,7 +516,7 @@ class PluginEscaladeTicket
                         // Sanitize before merging with $_POST['comment'] which is already sanitized
                         'content'    => Sanitizer::sanitize(
                             '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />'
-                        ) . $_POST['comment']
+                        )
                     ]);
                 }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/pluginsGLPI/escalade/issues/309
Prevent undefined index

```
[2025-03-19 12:07:51] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "comment" in glpi/marketplace/escalade/inc/ticket.class.php at line 519
``` 

`$_POST['comment'] is uselesse here (it's a bad copy/past)`

## Screenshots (if appropriate):
