### PR TITLE
Fix escalation when ticket contains mandatory fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Bypass filtering on the groups assignment` option
 - Fixed technician deletion when ticket updated
 - Fixed `Ticket status after an escalation` option
+- Fix escalation when ticket contains mandatory fields
 
 ## [2.9.11] - 2024-03-11
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -41,6 +41,12 @@ class PluginEscaladeTicket
 
     public static function pre_item_update(CommonDBTM $item)
     {
+        if ($item instanceof CommonITILObject) {
+            if (!$item->prepareInputForUpdate($item->input)) {
+                $item->input = false;
+                return false;
+            }
+        }
         if (
             isset($item->input['_itil_assign'])
             && $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #239 
- Here is a brief description of what this PR does

If a ticket contains mandatory fields and the actor list is escalated to fill in the mandatory field, abnormal behavior is displayed.
The task is created, the group is not updated and a popup appears saying that the mandatory field has not been filled in.
This PR checks whether the mandatory fields have been filled in before proceeding with any modifications/additions.
