### PR TITLE
2.9.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+## [2.9.11] - 2025-03-20
+
 ### Fixed
 
 - Calculation of status when a technician self-assigns to a ticket
@@ -14,7 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed technician deletion when ticket updated
 - Fixed `Ticket status after an escalation` option
 
-## [2.9.11] - 2024-03-11
+## [2.9.11] - 2025-03-11
 
 ### Fixed
 

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.9.12</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.12/glpi-escalade-2.9.12.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.11</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.11/glpi-escalade-2.9.11.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.11');
+define('PLUGIN_ESCALADE_VERSION', '2.9.12');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.11] - 2025-03-20

### Fixed

- Calculation of status when a technician self-assigns to a ticket
- Fixed `Bypass filtering on the groups assignment` option
- Fixed technician deletion when ticket updated
- Fixed `Ticket status after an escalation` option



Other

- It fixes #312 too

