### PR TITLE
fix(group): user was deleted during ticket creation with use_assign_user_group enabled

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -505,6 +505,7 @@ function plugin_escalade_item_add_ticket($item)
     if ($item instanceof Ticket) {
         unset($_SESSION['plugin_escalade']['skip_hook_add_user']);
         unset($_SESSION['plugin_escalade']['keep_users']);
+        unset($_SESSION['plugin_escalade']['ticket_creation']);
     }
 }
 
@@ -523,6 +524,7 @@ function plugin_escalade_item_add_group_ticket($item)
 function plugin_escalade_post_prepareadd_ticket($item)
 {
     if ($item instanceof Ticket) {
+        $_SESSION['plugin_escalade']['ticket_creation'] = true;
         return PluginEscaladeTicket::assignUserGroup($item);
     }
     return $item;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -588,9 +588,11 @@ class PluginEscaladeTicket
         if (
             $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] != 0
             && $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] != 0
+            && $_SESSION['plugin_escalade']['ticket_creation']
         ) {
             return;
         }
+
         if ($type == CommonITILActor::ASSIGN && !$_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
             return;
         }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -413,7 +413,12 @@ class PluginEscaladeTicket
             self::removeAssignGroups($tickets_id, $groups_id);
         }
         // The config is checked in the function.
-        self::removeAssignUsers($item);
+        if (
+            $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] == 0
+            || $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] == 0
+        ) {
+            self::removeAssignUsers($item);
+        }
 
         if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE) {
             $ticket = new Ticket();

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -413,12 +413,7 @@ class PluginEscaladeTicket
             self::removeAssignGroups($tickets_id, $groups_id);
         }
         // The config is checked in the function.
-        if (
-            $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] == 0
-            || $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] == 0
-        ) {
-            self::removeAssignUsers($item);
-        }
+        self::removeAssignUsers($item);
 
         if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE) {
             $ticket = new Ticket();
@@ -586,6 +581,13 @@ class PluginEscaladeTicket
         if (
             $_SESSION['glpi_plugins']['escalade']['config']['remove_tech'] == false
             && $_SESSION['glpi_plugins']['escalade']['config']['remove_requester'] == false
+        ) {
+            return;
+        }
+
+        if (
+            $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] != 0
+            && $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] != 0
         ) {
             return;
         }

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -53,7 +53,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             'use_assign_user_group_creation'     => 1,
             'use_assign_user_group_modification' => 1,
             'remove_tech'                        => 1,
-            'remove_groupe'                      => 1,
+            'remove_group'                       => 1,
         ] + $conf));
 
         PluginEscaladeConfig::loadInSession();
@@ -161,7 +161,11 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         // Update escalade config
         $this->assertTrue($config->update([
+            'use_assign_user_group'              => 1,
+            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_modification' => 1,
             'remove_tech'                        => 0,
+            'remove_group'                       => 0,
         ] + $conf));
 
         PluginEscaladeConfig::loadInSession();
@@ -239,7 +243,11 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         // Update escalade config
         $this->assertTrue($config->update([
+            'use_assign_user_group'              => 1,
+            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_modification' => 1,
             'remove_tech'                        => 1,
+            'remove_group'                       => 0,
         ] + $conf));
 
         PluginEscaladeConfig::loadInSession();

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -37,7 +37,7 @@ use PluginEscaladeConfig;
 
 final class GroupEscalationTest extends EscaladeTestCase
 {
-    public function testTechGroupAttribution()
+    public function testTechGroupAttributionUpdateTicket()
     {
         $this->login();
 
@@ -50,7 +50,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         // Update escalade config
         $this->assertTrue($config->update([
             'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_creation'     => 0,
             'use_assign_user_group_modification' => 1,
             'remove_tech'                        => 1,
             'remove_group'                       => 1,
@@ -137,6 +137,99 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
         // Check group assigned to the ticket
         $this->assertEquals($group2_id, $ticket_group2->fields['groups_id']);
+
+        $ticket_user = new \Ticket_User();
+        // Check user assigned to the ticket
+        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id])));
+
+        // Check requester
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID(), 'type' => CommonITILActor::REQUESTER])));
+
+        // Check assign
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
+    }
+
+    public function testTechGroupAttributionAddTicket()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        // Update escalade config
+        $this->assertTrue($config->update([
+            'use_assign_user_group'              => 1,
+            'use_assign_user_group_creation'     => 1,
+            'use_assign_user_group_modification' => 0,
+            'remove_tech'                        => 1,
+            'remove_group'                       => 1,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $group1 = new \Group();
+        $group1_id = $group1->add(['name' => 'Group_1']);
+        $this->assertGreaterThan(0, $group1_id);
+
+        $user_group1 = new \Group_User();
+        $user_group1->add([
+            'users_id' => $user1->getID(),
+            'groups_id' => $group1->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $group2 = new \Group();
+        $group2_id = $group2->add(['name' => 'Group_2']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $user_group2 = new \Group_User();
+        $user_group2->add([
+            'users_id' => $user2->getID(),
+            'groups_id' => $group2->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group2->getID());
+
+        // Create ticket with technician
+        $ticket = new \Ticket();
+        $t_id = $ticket->add([
+            'name' => 'Assign Group Escalation Test',
+            'content' => '',
+            '_actors' => [
+                'requester' => [
+                    [
+                        'items_id' => $user1->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+                'assign' => [
+                    [
+                        'items_id' => $user2->getID(),
+                        'itemtype' => 'User'
+                    ]
+                ],
+            ]
+        ]);
+
+        // Check one group linked to the ticket
+        $ticket_group = new \Group_Ticket();
+        $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
+
+        $ticket_group->getFromDBByCrit([
+            'tickets_id' => $t_id,
+        ]);
+        // Check group assigned to the ticket
+        $this->assertEquals($group2_id, $ticket_group->fields['groups_id']);
 
         $ticket_user = new \Ticket_User();
         // Check user assigned to the ticket

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -51,7 +51,9 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertTrue($config->update([
             'use_assign_user_group'              => 1,
             'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 1
+            'use_assign_user_group_modification' => 1,
+            'remove_tech'                        => 1,
+            'remove_groupe'                      => 1,
         ] + $conf));
 
         PluginEscaladeConfig::loadInSession();

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -297,16 +297,16 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         $ticket_user = new \Ticket_User();
         // Check user assigned to the ticket
-        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id])));
+        $this->assertEquals(3, count($ticket_user->find(['tickets_id' => $t_id])));
 
         // Check requester
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID(), 'type' => CommonITILActor::REQUESTER])));
 
         // Check assign user2
-        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
-
-        // Check assign user
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
+
+        // Check assign user3
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user3->getID(), 'type' => CommonITILActor::ASSIGN])));
     }
 
     public function testUserWithsGroupAttributionWithoutRemoveTechConfig()


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36974
- This PR fixes the bug that deleted the user during the assignment of his group when creating a ticket, when the option 'Use the technician’s group' was enabled.

## Screenshots (if appropriate):

![Capture d’écran du 2025-03-21 14-05-57](https://github.com/user-attachments/assets/aefbf594-5e88-4b37-8e11-edf6267d1e10)

![Capture d’écran du 2025-03-21 14-05-17](https://github.com/user-attachments/assets/ee0e322e-2fe9-4c57-bed4-5ed4aa274cd4)

