### PR TITLE
Fix history disapear when we use Escalate button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Bypass filtering on the groups assignment` option
 - Fixed technician deletion when ticket updated
 - Fixed `Ticket status after an escalation` option
+- Fixed `show_history` option when climbing with the button `Escalate`
 
 ## [2.9.11] - 2024-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed `Bypass filtering on the groups assignment` option
 - Fixed technician deletion when ticket updated
 - Fixed `Ticket status after an escalation` option
-- Fixed `show_history` option when climbing with the button `Escalate`
+- Fixed `show_history` option when using the `Escalate` button.
 
 ## [2.9.11] - 2024-03-11
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -97,7 +97,6 @@ class PluginEscaladeTicket
                     $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                 }
                 self::removeAssignUsers($item);
-                return PluginEscaladeTicket::addHistoryOnAddGroup($item);
             } elseif (count($old_groups) == count($new_groups)) {
                 $old_group_ids = [];
                 foreach ($old_groups as $old_group) {
@@ -112,7 +111,6 @@ class PluginEscaladeTicket
                             $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                         }
                         self::removeAssignUsers($item);
-                        return PluginEscaladeTicket::addHistoryOnAddGroup($item);
                     }
                 }
             }
@@ -320,7 +318,7 @@ class PluginEscaladeTicket
             return;
         }
 
-        $tickets_id = $item->input['id'];
+        $tickets_id = $item->input['id'] ?? $item->input['tickets_id'];
         $groups_id  = $item->input['groups_id'];
 
         $item->fields['status'] = CommonITILObject::ASSIGNED;
@@ -421,6 +419,11 @@ class PluginEscaladeTicket
                 'id'     => $tickets_id,
                 'status' => $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status']
             ]);
+        }
+
+        if ($_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true) {
+            $item->input['actortype'] = $item->fields['type'];
+            PluginEscaladeTicket::addHistoryOnAddGroup($item);
         }
     }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -366,9 +366,6 @@ class PluginEscaladeTicket
             }
         }
 
-        //remove old user(s) (pass if user added by new ticket)
-        self::removeAssignUsers($item);
-
         //add a task to inform the escalation (pass if solution)
         if (isset($_SESSION['plugin_escalade']['solution'])) {
             unset($_SESSION['plugin_escalade']['solution']);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -318,7 +318,13 @@ class PluginEscaladeTicket
             return;
         }
 
-        $tickets_id = $item->input['id'] ?? $item->input['tickets_id'];
+        if ($item instanceof Ticket) {
+            $tickets_id = $item->input['id'];
+        } elseif (isset($item->input['tickets_id'])) {
+            $tickets_id = $item->input['tickets_id'];
+        } else {
+            return false;
+        }
         $groups_id  = $item->input['groups_id'];
 
         $item->fields['status'] = CommonITILObject::ASSIGNED;

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -354,7 +354,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             '_actors' => [
                 'assign' => [
                     [
-                        'items_id' => $group2_id(),
+                        'items_id' => $group2_id,
                         'itemtype' => 'Group'
                     ],
                 ],
@@ -379,7 +379,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             '_actors' => [
                 'assign' => [
                     [
-                        'items_id' => $group1_id(),
+                        'items_id' => $group1_id,
                         'itemtype' => 'Group'
                     ],
                 ],

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -345,7 +345,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($history->find(['tickets_id' => $t_id, 'groups_id' => $group1_id])));
 
         $group2 = new \Group();
-        $group2_id = $group1->add(['name' => 'Group_history_2']);
+        $group2_id = $group2->add(['name' => 'Group_history_2']);
         $this->assertGreaterThan(0, $group2_id);
 
         $ticket = new \Ticket();
@@ -354,7 +354,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             '_actors' => [
                 'assign' => [
                     [
-                        'items_id' => $group2->getID(),
+                        'items_id' => $group2_id(),
                         'itemtype' => 'Group'
                     ],
                 ],
@@ -379,7 +379,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             '_actors' => [
                 'assign' => [
                     [
-                        'items_id' => $group1->getID(),
+                        'items_id' => $group1_id(),
                         'itemtype' => 'Group'
                     ],
                 ],

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -302,4 +302,93 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $t_id])));
         $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
     }
+
+    public function testHistory()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        // Update escalade config
+        $this->assertTrue($config->update([
+            'show_history' => 1,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $group1 = new \Group();
+        $group1_id = $group1->add(['name' => 'Group_history_1']);
+        $this->assertGreaterThan(0, $group1_id);
+
+        // Create ticket without technician
+        $ticket = new \Ticket();
+        $t_id = $ticket->add([
+            'name' => 'Assign Group Escalation Test',
+            'content' => '',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group1_id,
+                        'itemtype' => 'Group'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $t_id);
+
+        $history = new \PluginEscaladeHistory();
+        $this->assertEquals(1, count($history->find(['tickets_id' => $t_id,])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $t_id, 'groups_id' => $group1_id])));
+
+        $group2 = new \Group();
+        $group2_id = $group1->add(['name' => 'Group_history_2']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $ticket = new \Ticket();
+        $ticket_update = $ticket->update([
+            'id' => $t_id,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group2->getID(),
+                        'itemtype' => 'Group'
+                    ],
+                ],
+            ]
+        ]);
+        $this->assertTrue($ticket_update);
+
+        $history = new \PluginEscaladeHistory();
+        $this->assertEquals(2, count($history->find(['tickets_id' => $t_id])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $t_id, 'groups_id' => $group1_id])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $t_id, 'groups_id' => $group2_id])));
+
+        $this->assertTrue($config->update([
+            'show_history' => 0,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $ticket = new \Ticket();
+        $ticket_update = $ticket->update([
+            'id' => $t_id,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group1->getID(),
+                        'itemtype' => 'Group'
+                    ],
+                ],
+            ]
+        ]);
+        $this->assertTrue($ticket_update);
+
+        $history = new \PluginEscaladeHistory();
+        $this->assertEquals(2, count($history->find(['tickets_id' => $t_id])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $t_id, 'groups_id' => $group1_id])));
+    }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36732
- Here is a brief description of what this PR does
When using the escalation button to escalate the ticket to another group, the history function does not work. 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/455920e3-35f9-4d21-80ff-210a1a0cb88f)

