### PR TITLE
fix: remove technician on ticket escalation if no group is assigned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix Escalate timeline button execute RuleTicket
 - Fix group assign with `reassign_group_from_cat` option
+- Fix the `remove_tech` option when a user was added to a ticket
 
 
 ## [2.9.13] - 2025-03-31

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -190,7 +190,7 @@ class PluginEscaladeTicket
         }
 
         //ticket qualification on cat change
-        if (isset($item->updates['itilcategories_id'])) {
+        if (isset($item->updates['itilcategories_id']) || in_array('itilcategories_id', $item->updates)) {
             self::qualification($item);
         }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -48,6 +48,7 @@ class PluginEscaladeTicket
         }
 
         $old_groups = [];
+        $old_users = [];
 
         // Get actual actors for the ticket
         if ($item instanceof Ticket) {
@@ -63,6 +64,15 @@ class PluginEscaladeTicket
 
             $old_groups = array_filter($ticket_actors['assign'], function ($actor) {
                 return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
+            });
+
+            $old_users = array_filter($ticket_actors['assign'], function ($actor) use ($item) {
+                return isset($actor['itemtype'])
+                    && $actor['itemtype'] === 'User'
+                    && (
+                        !isset($item->input['_itil_assign']) ||
+                        (isset($actor['items_id']) && $item->input['_itil_assign']['users_id'] != $actor['items_id'])
+                    );
             });
         }
         if (!isset($item->input['actortype'])) {
@@ -86,15 +96,6 @@ class PluginEscaladeTicket
                     return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
                 });
             }
-
-            $old_users = array_filter($ticket_actors['assign'], function ($actor) use ($item) {
-                return isset($actor['itemtype'])
-                    && $actor['itemtype'] === 'User'
-                    && (
-                        !isset($item->input['_itil_assign']) ||
-                        (isset($actor['items_id']) && $item->input['_itil_assign']['users_id'] != $actor['items_id'])
-                    );
-            });
 
             $new_users = $old_users;
             if (isset($item->input['_actors']['assign'])) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -119,7 +119,7 @@ class PluginEscaladeTicket
                     $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                 }
                 self::removeAssignUsers($item);
-            } elseif (count($old_groups) == count($new_groups) && count($old_users) < count($new_users)) {
+            } elseif (count($old_groups) == count($new_groups)) {
                 $old_group_ids = [];
                 foreach ($old_groups as $old_group) {
                     $old_group_ids[$old_group['items_id']] = true;
@@ -134,7 +134,9 @@ class PluginEscaladeTicket
                         }
                     }
                 }
-                self::removeAssignUsers($item);
+                if (count($old_users) < count($new_users)) {
+                    self::removeAssignUsers($item);
+                }
             }
 
             return $item;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -624,6 +624,13 @@ class PluginEscaladeTicket
         }
 
         if (
+            isset($_SESSION['plugin_escalade']['ticket_creation'])
+            && $_SESSION['plugin_escalade']['ticket_creation']
+        ) {
+            return;
+        }
+
+        if (
             $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] != 0
             && $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] != 0
             && isset($_SESSION['plugin_escalade']['ticket_creation'])
@@ -866,6 +873,7 @@ class PluginEscaladeTicket
             ];
             $user_found = $ticket_user->find($user_condition);
             if (empty($user_found)) {
+                self::removeAssignUsers($item);
                 //add user to ticket
                 $ticket_user->add($user_condition);
                 //remove old tech if needed

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -78,11 +78,19 @@ class PluginEscaladeTicket
             }
         }
         if (
-            isset($item->input['_actors']['assign'])
+            isset($item->input['_actors']['assign']) || isset($item->input['_itil_assign'])
         ) {
-            $new_groups = array_filter($item->input['_actors']['assign'], function ($actor) {
-                return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
-            });
+            $new_groups = [];
+            if (isset($item->input['_actors']['assign'])) {
+                $new_groups = array_filter($item->input['_actors']['assign'], function ($actor) {
+                    return isset($actor['itemtype']) && $actor['itemtype'] === 'Group';
+                });
+            } else {
+                $new_groups = array_filter($item->input['_itil_assign'], function ($actor) {
+                    return isset($actor['_type']) && $actor['itemtype'] === 'user';
+                });
+            }
+
 
             if (
                 (isset($item->input['actortype']) && $item->input['actortype'] == CommonITILActor::ASSIGN) &&

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -110,9 +110,9 @@ class PluginEscaladeTicket
                             $item->input['_do_not_compute_status'] = true;
                             $item->input['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
                         }
-                        self::removeAssignUsers($item);
                     }
                 }
+                self::removeAssignUsers($item);
             }
 
             return $item;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -106,7 +106,7 @@ class PluginEscaladeTicket
                 $new_users[] = [
                     'items_id' => $item->input['_itil_assign']['users_id'],
                     'itemtype' => 'User',
-                    'use_notification' => $item->input['_itil_assign']['use_notification'],
+                    'use_notification' => isset($item->input['_itil_assign']['use_notification']) ?? false,
                 ];
             }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -103,7 +103,11 @@ class PluginEscaladeTicket
                     return isset($actor['itemtype']) && $actor['itemtype'] === 'User';
                 });
             } elseif (isset($item->input['_itil_assign']['_type']) && $item->input['_itil_assign']['_type'] === 'user') {
-                $new_users[] = $item->input['_itil_assign'];
+                $new_users[] = [
+                    'items_id' => $item->input['_itil_assign']['users_id'],
+                    'itemtype' => 'User',
+                    'use_notification' => $item->input['_itil_assign']['use_notification'],
+                ];
             }
 
 
@@ -136,7 +140,11 @@ class PluginEscaladeTicket
                     }
                 }
                 if (count($old_users) < count($new_users)) {
-                    self::removeAssignUsers($item);
+                    $old_ids = array_column($old_users, 'items_id');
+                    $keep_users = array_filter($new_users, function ($user) use ($old_ids) {
+                        return !in_array($user['items_id'], $old_ids);
+                    });
+                    self::removeAssignUsers($item, array_column($keep_users, 'items_id'));
                 }
             }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -476,22 +476,18 @@ class PluginEscaladeTicket
                         current($ticket->input['_users_id_assign']),
                         true
                     );
-                //prevent adding empty group
-                if (empty($ticket->input['_groups_id_assign'])) {
-                    unset($ticket->input['_groups_id_assign']);
-                }
             } else {
                 // All groups
-                $ticket->input['_additional_groups_assigns']
+                $ticket->input['_groups_id_assign']
                     = PluginEscaladeUser::getTechnicianGroup(
                         $ticket->input['entities_id'],
-                        $ticket->input['_users_id_assign'],
+                        current($ticket->input['_users_id_assign']),
                         false
                     );
-                //prevent adding empty group
-                if (empty($ticket->input['_additional_groups_assigns'])) {
-                    unset($ticket->input['_additional_groups_assigns']);
-                }
+            }
+            //prevent adding empty group
+            if (empty($ticket->input['_groups_id_assign'])) {
+                unset($ticket->input['_groups_id_assign']);
             }
         }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -106,7 +106,7 @@ class PluginEscaladeTicket
                 $new_users[] = [
                     'items_id' => $item->input['_itil_assign']['users_id'],
                     'itemtype' => 'User',
-                    'use_notification' => isset($item->input['_itil_assign']['use_notification']) ?? false,
+                    'use_notification' => $item->input['_itil_assign']['use_notification'] ?? false,
                 ];
             }
 

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -629,16 +629,11 @@ final class GroupEscalationTest extends EscaladeTestCase
         foreach ($this->testTechGroupAttributionProvider() as $provider) {
             $this->login();
 
-            $config = new PluginEscaladeConfig();
-            $conf = $config->find();
-            $conf = reset($conf);
-            $config->getFromDB($conf['id']);
-            $this->assertGreaterThan(0, $conf['id']);
             // Update escalade config
             $this->updateItem(
                 PluginEscaladeConfig::class,
-                $conf['id'],
-                array_merge($conf, $provider['conf']),
+                1,
+                $provider['conf'],
             );
 
             PluginEscaladeConfig::loadInSession();

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -149,34 +149,448 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
     }
 
-    public function testTechGroupAttributionAddTicketKeepTech()
+    private function testTechGroupAttributionProvider()
     {
-        $this->login();
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 0,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 0,
+            ]
+        ];
 
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 0,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 0,
+            ]
+        ];
 
-        // Update escalade config
-        $this->assertTrue($config->update([
-            'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 0,
-            'remove_tech'                        => 0,
-            'remove_group'                       => 1,
-        ] + $conf));
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 0,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ]
+        ];
 
-        PluginEscaladeConfig::loadInSession();
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
 
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 2,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 2,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 1,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 0,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 0,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 0,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 2,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 0,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 2,
+                'group_ticket' => 1,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 0,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 2,
+            ]
+        ];
+
+        yield [
+            'conf' => [
+                'use_assign_user_group'              => 2,
+                'use_assign_user_group_creation'     => 1,
+                'use_assign_user_group_modification' => 1,
+                'remove_tech'                        => 1,
+                'remove_group'                       => 1,
+            ],
+            'add_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ],
+            'update_expected' => [
+                'user_ticket' => 1,
+                'group_ticket' => 1,
+            ]
+        ];
+    }
+
+    public function testTechGroupAttributionAddTicket()
+    {
         $user1 = new \User();
         $user1->getFromDBbyName('glpi');
         $this->assertGreaterThan(0, $user1->getID());
 
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
         $group1 = new \Group();
-        $group1_id = $group1->add(['name' => 'Group_1']);
+        $group1_id = $group1->add(['name' => 'GLPI Group_1']);
         $this->assertGreaterThan(0, $group1_id);
+
+        $group3 = new \Group();
+        $group3_id = $group3->add(['name' => 'GLPI Group_2']);
+        $this->assertGreaterThan(0, $group3_id);
+
+        $group2 = new \Group();
+        $group2_id = $group2->add(['name' => 'TECH Group_1']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $group4 = new \Group();
+        $group4_id = $group4->add(['name' => 'TECH Group_2']);
+        $this->assertGreaterThan(0, $group4_id);
 
         $user_group1 = new \Group_User();
         $user_group1->add([
@@ -185,14 +599,6 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
         $this->assertGreaterThan(0, $user_group1->getID());
 
-        $user2 = new \User();
-        $user2->getFromDBbyName('tech');
-        $this->assertGreaterThan(0, $user2->getID());
-
-        $group2 = new \Group();
-        $group2_id = $group2->add(['name' => 'Group_2']);
-        $this->assertGreaterThan(0, $group2_id);
-
         $user_group2 = new \Group_User();
         $user_group2->add([
             'users_id' => $user2->getID(),
@@ -200,437 +606,114 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
         $this->assertGreaterThan(0, $user_group2->getID());
 
-        $user3 = new \User();
-        $user3->getFromDBbyName('normal');
-        $this->assertGreaterThan(0, $user3->getID());
-
-        $group3 = new \Group();
-        $group3_id = $group3->add(['name' => 'Group_3']);
-        $this->assertGreaterThan(0, $group3_id);
-
         $user_group3 = new \Group_User();
         $user_group3->add([
-            'users_id' => $user3->getID(),
-            'groups_id' => $group3->getID()
-        ]);
-        $this->assertGreaterThan(0, $user_group3->getID());
-
-        // Create ticket with technician
-        $ticket = new \Ticket();
-        $t_id = $ticket->add([
-            'name' => 'Assign Group Escalation Test',
-            'content' => '',
-            '_actors' => [
-                'requester' => [
-                    [
-                        'items_id' => $user1->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-                'assign' => [
-                    [
-                        'items_id' => $user2->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-            ]
-        ]);
-
-        // Check one group linked to the ticket
-        $ticket_group = new \Group_Ticket();
-        $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
-
-        $ticket_group->getFromDBByCrit([
-            'tickets_id' => $t_id,
-        ]);
-        // Check group assigned to the ticket
-        $this->assertEquals($group2_id, $ticket_group->fields['groups_id']);
-
-        $ticket_user = new \Ticket_User();
-        // Check user assigned to the ticket
-        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id])));
-
-        // Check requester
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID(), 'type' => CommonITILActor::REQUESTER])));
-
-        // Check assign
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
-
-        // Update ticket with a technician
-        $this->assertTrue($ticket->update(
-            [
-                'id' => $t_id,
-                '_actors' => [
-                    'requester' => [
-                        [
-                            'items_id' => $user1->getID(),
-                            'itemtype' => 'User'
-                        ]
-                    ],
-                    'assign' => [
-                        [
-                            'items_id' => $user2->getID(),
-                            'itemtype' => 'User'
-                        ],
-                        [
-                            'items_id' => $group2->getID(),
-                            'itemtype' => 'Group'
-                        ],
-                        [
-                            'items_id' => $user3->getID(),
-                            'itemtype' => 'User'
-                        ]
-                    ],
-                ],
-            ]
-        ));
-
-        // Check one group linked to the ticket
-        $ticket_group = new \Group_Ticket();
-        $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
-
-        $ticket_group->getFromDBByCrit([
-            'tickets_id' => $t_id,
-        ]);
-        // Check group assigned to the ticket
-        $this->assertEquals($group2_id, $ticket_group->fields['groups_id']);
-
-        $ticket_user = new \Ticket_User();
-        // Check user assigned to the ticket
-        $this->assertEquals(3, count($ticket_user->find(['tickets_id' => $t_id])));
-
-        // Check requester
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID(), 'type' => CommonITILActor::REQUESTER])));
-
-        // Check user2 has been assigned
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
-
-        // Check user3 has been assigned
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user3->getID(), 'type' => CommonITILActor::ASSIGN])));
-    }
-
-    public function testTechGroupAttributionAddTicketRemoveTech()
-    {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-
-        // Update escalade config
-        $this->assertTrue($config->update([
-            'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 0,
-            'remove_tech'                        => 1,
-            'remove_group'                       => 1,
-        ] + $conf));
-
-        PluginEscaladeConfig::loadInSession();
-
-        $user1 = new \User();
-        $user1->getFromDBbyName('glpi');
-        $this->assertGreaterThan(0, $user1->getID());
-
-        $group1 = new \Group();
-        $group1_id = $group1->add(['name' => 'Group_1']);
-        $this->assertGreaterThan(0, $group1_id);
-
-        $user_group1 = new \Group_User();
-        $user_group1->add([
             'users_id' => $user1->getID(),
-            'groups_id' => $group1->getID()
-        ]);
-        $this->assertGreaterThan(0, $user_group1->getID());
-
-        $user2 = new \User();
-        $user2->getFromDBbyName('tech');
-        $this->assertGreaterThan(0, $user2->getID());
-
-        $group2 = new \Group();
-        $group2_id = $group2->add(['name' => 'Group_2']);
-        $this->assertGreaterThan(0, $group2_id);
-
-        $user_group2 = new \Group_User();
-        $user_group2->add([
-            'users_id' => $user2->getID(),
-            'groups_id' => $group2->getID()
-        ]);
-        $this->assertGreaterThan(0, $user_group2->getID());
-
-        $user3 = new \User();
-        $user3->getFromDBbyName('normal');
-        $this->assertGreaterThan(0, $user3->getID());
-
-        $group3 = new \Group();
-        $group3_id = $group3->add(['name' => 'Group_3']);
-        $this->assertGreaterThan(0, $group3_id);
-
-        $user_group3 = new \Group_User();
-        $user_group3->add([
-            'users_id' => $user3->getID(),
             'groups_id' => $group3->getID()
         ]);
         $this->assertGreaterThan(0, $user_group3->getID());
 
-        // Create ticket with technician
-        $ticket = new \Ticket();
-        $t_id = $ticket->add([
-            'name' => 'Assign Group Escalation Test',
-            'content' => '',
-            '_actors' => [
-                'requester' => [
-                    [
-                        'items_id' => $user1->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-                'assign' => [
-                    [
-                        'items_id' => $user2->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-            ]
+        $user_group4 = new \Group_User();
+        $user_group4->add([
+            'users_id' => $user2->getID(),
+            'groups_id' => $group4->getID()
         ]);
+        $this->assertGreaterThan(0, $user_group4->getID());
+        foreach ($this->testTechGroupAttributionProvider() as $provider) {
+            $this->login();
 
-        // Check one group linked to the ticket
-        $ticket_group = new \Group_Ticket();
-        $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
+            $config = new PluginEscaladeConfig();
+            $conf = $config->find();
+            $conf = reset($conf);
+            $config->getFromDB($conf['id']);
+            $this->assertGreaterThan(0, $conf['id']);
+            // Update escalade config
+            $conf = array_merge($conf, $provider['conf']);
+            $this->assertTrue($config->update($conf));
 
-        $ticket_group->getFromDBByCrit([
-            'tickets_id' => $t_id,
-        ]);
-        // Check group assigned to the ticket
-        $this->assertEquals($group2_id, $ticket_group->fields['groups_id']);
+            PluginEscaladeConfig::loadInSession();
 
-        $ticket_user = new \Ticket_User();
-        // Check user assigned to the ticket
-        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id])));
-
-        // Check requester
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID(), 'type' => CommonITILActor::REQUESTER])));
-
-        // Check assign
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
-
-        // Update ticket with a technician
-        $this->assertTrue($ticket->update(
-            [
-                'id' => $t_id,
+            $ticket = new \Ticket();
+            $t_id = $ticket->add([
+                'name' => 'Assign Group Escalation Test',
+                'content' => '',
                 '_actors' => [
-                    'requester' => [
+                    'assign' => [
                         [
                             'items_id' => $user1->getID(),
                             'itemtype' => 'User'
                         ]
                     ],
-                    'assign' => [
-                        [
-                            'items_id' => $user2->getID(),
-                            'itemtype' => 'User'
-                        ],
-                        [
-                            'items_id' => $group2->getID(),
-                            'itemtype' => 'Group'
-                        ],
-                        [
-                            'items_id' => $user3->getID(),
-                            'itemtype' => 'User'
-                        ]
-                    ],
+                ]
+            ]);
+
+            $this->assertGreaterThan(0, $t_id);
+
+            $ticket_user = new \Ticket_User();
+            $this->assertEquals($provider['add_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+
+            $group_ticket = new \Group_Ticket();
+            $this->assertEquals($provider['add_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+
+            if ($provider['conf']['use_assign_user_group_creation'] === 1) {
+                $group = $group_ticket->getFromDBByCrit(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN]);
+                $this->assertTrue($group);
+                if ($provider['conf']['use_assign_user_group'] === 1) {
+                    $this->assertEquals($group_ticket->fields['groups_id'], $group1->getID());
+                }
+                if ($provider['conf']['use_assign_user_group'] === 2) {
+                    $this->assertEquals($group_ticket->fields['groups_id'], $group3->getID());
+                }
+            }
+
+            $assign = [
+                [
+                    'items_id' => $user2->getID(),
+                    'itemtype' => 'User'
                 ],
-            ]
-        ));
+                [
+                    'items_id' => $user1->getID(),
+                    'itemtype' => 'User'
+                ]
+            ];
 
-        // Check one group linked to the ticket
-        $ticket_group = new \Group_Ticket();
-        $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
-
-        $ticket_group->getFromDBByCrit([
-            'tickets_id' => $t_id,
-        ]);
-        // Check group assigned to the ticket
-        $this->assertEquals($group2_id, $ticket_group->fields['groups_id']);
-
-        $ticket_user = new \Ticket_User();
-        // Check user assigned to the ticket
-        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id])));
-
-        // Check requester
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID(), 'type' => CommonITILActor::REQUESTER])));
-
-        // Check that user2 has been removed
-        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID(), 'type' => CommonITILActor::ASSIGN])));
-
-        // Verify that user3 has been assigned
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user3->getID(), 'type' => CommonITILActor::ASSIGN])));
-    }
-
-    public function testUserWithsGroupAttributionWithoutRemoveTechConfig()
-    {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-
-        // Update escalade config
-        $this->assertTrue($config->update([
-            'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 1,
-            'remove_tech'                        => 0,
-            'remove_group'                       => 0,
-        ] + $conf));
-
-        PluginEscaladeConfig::loadInSession();
-
-        $user1 = new \User();
-        $user1->getFromDBbyName('glpi');
-        $this->assertGreaterThan(0, $user1->getID());
-
-        $user2 = new \User();
-        $user2->getFromDBbyName('tech');
-        $this->assertGreaterThan(0, $user2->getID());
-
-        $group2 = new \Group();
-        $group2_id = $group2->add(['name' => 'Group_2']);
-        $this->assertGreaterThan(0, $group2_id);
-
-        $user_group2 = new \Group_User();
-        $user_group2->add([
-            'users_id' => $user2->getID(),
-            'groups_id' => $group2->getID()
-        ]);
-        $this->assertGreaterThan(0, $user_group2->getID());
-
-        // Create ticket without technician
-        $ticket = new \Ticket();
-        $t_id = $ticket->add([
-            'name' => 'Assign Group Escalation Test',
-            'content' => '',
-            '_actors' => [
-                'assign' => [
-                    [
-                        'items_id' => $user1->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-            ]
-        ]);
-        $this->assertGreaterThan(0, $t_id);
-
-        $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
-
-        $ticket = new \Ticket();
-        $ticket_update = $ticket->update([
-            'id' => $t_id,
-            '_actors' => [
-                'assign' => [
-                    [
-                        'items_id' => $group2->getID(),
+            if (!empty($provider['conf']['use_assign_user_group_creation'])) {
+                if ($provider['conf']['use_assign_user_group'] === 1) {
+                    $assign[] = [
+                        'items_id' => $group1->getID(),
                         'itemtype' => 'Group'
-                    ],
-                    [
-                        'items_id' => $user1->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-            ]
-        ]);
-        $this->assertTrue($ticket_update);
-
-        $group_ticket = new \Group_Ticket();
-        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $t_id])));
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
-    }
-
-    public function testUserWithsGroupAttributionWithsRemoveTechConfig()
-    {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-
-        // Update escalade config
-        $this->assertTrue($config->update([
-            'use_assign_user_group'              => 1,
-            'use_assign_user_group_creation'     => 1,
-            'use_assign_user_group_modification' => 1,
-            'remove_tech'                        => 1,
-            'remove_group'                       => 0,
-        ] + $conf));
-
-        PluginEscaladeConfig::loadInSession();
-
-        $user1 = new \User();
-        $user1->getFromDBbyName('glpi');
-        $this->assertGreaterThan(0, $user1->getID());
-
-        $user2 = new \User();
-        $user2->getFromDBbyName('tech');
-        $this->assertGreaterThan(0, $user2->getID());
-
-        $group2 = new \Group();
-        $group2_id = $group2->add(['name' => 'Group_2']);
-        $this->assertGreaterThan(0, $group2_id);
-
-        $user_group2 = new \Group_User();
-        $user_group2->add([
-            'users_id' => $user2->getID(),
-            'groups_id' => $group2->getID()
-        ]);
-        $this->assertGreaterThan(0, $user_group2->getID());
-
-        // Create ticket without technician
-        $ticket = new \Ticket();
-        $t_id = $ticket->add([
-            'name' => 'Assign Group Escalation Test',
-            'content' => '',
-            '_actors' => [
-                'assign' => [
-                    [
-                        'items_id' => $user1->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-            ]
-        ]);
-        $this->assertGreaterThan(0, $t_id);
-
-        $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
-
-        $ticket = new \Ticket();
-        $ticket_update = $ticket->update([
-            'id' => $t_id,
-            '_actors' => [
-                'assign' => [
-                    [
-                        'items_id' => $group2->getID(),
+                    ];
+                }
+                if ($provider['conf']['use_assign_user_group'] === 2) {
+                    $assign[] = [
+                        'items_id' => $group3->getID(),
                         'itemtype' => 'Group'
-                    ],
-                    [
-                        'items_id' => $user1->getID(),
-                        'itemtype' => 'User'
-                    ]
-                ],
-            ]
-        ]);
-        $this->assertTrue($ticket_update);
+                    ];
+                }
+            }
 
-        $group_ticket = new \Group_Ticket();
-        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $t_id])));
-        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+            $ticket_update = $ticket->update([
+                'id'      => $t_id,
+                '_actors' => [
+                    'assign' => $assign
+                ]
+            ]);
+            $this->assertTrue($ticket_update);
+
+            $this->assertEquals($provider['update_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+            $this->assertEquals($provider['update_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
+
+            if ($provider['conf']['use_assign_user_group_modification'] === 1) {
+                if ($provider['conf']['use_assign_user_group'] === 1) {
+                    $group = $group_ticket->getFromDBByCrit(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN, 'groups_id' => $group2->getID()]);
+                    $this->assertTrue($group);
+                }
+                if ($provider['conf']['use_assign_user_group'] === 2) {
+                    $group = $group_ticket->getFromDBByCrit(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN, 'groups_id' => $group4->getID()]);
+                    $this->assertTrue($group);
+                }
+            }
+        }
     }
 
     public function testHistory()

--- a/tests/units/GroupEscalationTest.php
+++ b/tests/units/GroupEscalationTest.php
@@ -700,6 +700,8 @@ final class GroupEscalationTest extends EscaladeTestCase
             ]);
             $this->assertTrue($ticket_update);
 
+            $temp = $ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN]);
+
             $this->assertEquals($provider['update_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
             $this->assertEquals($provider['update_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $t_id, 'type' => CommonITILActor::ASSIGN])));
 

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -696,9 +696,9 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 0,
+                'users' => 1,
                 'groups' => 1,
-                'user_1_is_assign' => 0,
+                'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
                 'group_2_is_assign' => 0,
@@ -764,9 +764,9 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 0,
+                'users' => 1,
                 'groups' => 1,
-                'user_1_is_assign' => 0,
+                'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
                 'group_2_is_assign' => 0,
@@ -904,8 +904,8 @@ final class TicketTest extends EscaladeTestCase
             ]);
             $this->assertGreaterThan(0, $t_id);
             $count_user1_assign_add = $provider['conf']['remove_tech'] === 0 ? 1 : 0;
-            $this->assertEquals($count_user1_assign_add, count($ticket_user->find(['tickets_id' => $t_id])));
-            $this->assertEquals($count_user1_assign_add, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID()])));
+            $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id])));
+            $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID()])));
             $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID()])));
             $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
             $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id, 'groups_id' => $group1->getID()])));

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -765,6 +765,7 @@ final class TicketTest extends EscaladeTestCase
         $entity = new \Entity();
         $entity->getFromDB(0);
         $entity->update([
+            "id" => 0,
             "auto_assign_mode" => 2,
         ]);
 

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -33,6 +33,7 @@ namespace GlpiPlugin\Escalade\Tests\Units;
 use CommonITILActor;
 use CommonITILObject;
 use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
+use ITILCategory;
 use PluginEscaladeConfig;
 use PluginEscaladeTicket;
 
@@ -547,5 +548,297 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
         $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
         $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
+    }
+
+    private function testAssignGroupToTicketWithCategoryProvider()
+    {
+        yield [
+            'conf' => [
+                'remove_tech'  => 0,
+                'remove_group' => 0,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat' => 0,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 1,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 0,
+                'remove_group' => 0,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat' => 1,
+            ],
+            'expected' => [
+                'users' => 2,
+                'groups' => 1,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 0,
+                'remove_group' => 0,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat' => 0,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 2,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 0,
+                'remove_group' => 1,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat' => 1,
+            ],
+            'expected' => [
+                'users' => 2,
+                'groups' => 1,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 0,
+                'remove_group' => 1,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat' => 1,
+            ],
+            'expected' => [
+                'users' => 2,
+                'groups' => 1,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 0,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 1,
+                'remove_group' => 0,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat' => 0,
+            ],
+            'expected' => [
+                'users' => 0,
+                'groups' => 1,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 1,
+                'remove_group' => 0,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat' => 1,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 1,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 1,
+                'remove_group' => 0,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat' => 0,
+            ],
+            'expected' => [
+                'users' => 0,
+                'groups' => 2,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 1,
+                'remove_group' => 1,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat' => 1,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 1,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 1,
+                'remove_group' => 1,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat' => 0,
+            ],
+            'expected' => [
+                'users' => 0,
+                'groups' => 1,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 0,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'  => 1,
+                'remove_group' => 1,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat' => 1,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 1,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 0,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+    }
+
+    public function testAssignGroupToTicketWithCategory()
+    {
+        $ticket_user = new \Ticket_User();
+        $ticket_group = new \Group_Ticket();
+        $ticket = new \Ticket();
+        $itil_category = new \ITILCategory();
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $group1 = new \Group();
+        $group1_id = $group1->add(['name' => 'GLPI Group']);
+        $this->assertGreaterThan(0, $group1_id);
+
+        $user_group1 = new \Group_User();
+        $user_group1->add([
+            'users_id' => $user1->getID(),
+            'groups_id' => $group1->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group1->getID());
+
+        $entity = new \Entity();
+        $entity->getFromDB(0);
+        $entity->update([
+            "auto_assign_mode" => 2,
+        ]);
+
+        $itil_category1_id = $itil_category->add([
+            'name' => 'Cat1',
+            'users_id' => $user1->getID(),
+            'groups_id' => $group1->getID(),
+        ]);
+        $this->assertGreaterThan(0, $itil_category1_id);
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $group2 = new \Group();
+        $group2_id = $group2->add(['name' => 'TECH Group']);
+        $this->assertGreaterThan(0, $group2_id);
+
+        $user_group2 = new \Group_User();
+        $user_group2->add([
+            'users_id' => $user2->getID(),
+            'groups_id' => $group2->getID()
+        ]);
+        $this->assertGreaterThan(0, $user_group2->getID());
+
+        $itil_category2_id = $itil_category->add([
+            'name' => 'Cat2',
+            'users_id' => $user2->getID(),
+            'groups_id' => $group2->getID(),
+        ]);
+        $this->assertGreaterThan(0, $itil_category2_id);
+
+        foreach ($this->testAssignGroupToTicketWithCategoryProvider() as $provider) {
+            $this->login();
+
+            $config = new PluginEscaladeConfig();
+            $conf = $config->find();
+            $conf = reset($conf);
+            $config->getFromDB($conf['id']);
+            $this->assertGreaterThan(0, $conf['id']);
+            // Update escalade config
+            $conf = array_merge($conf, $provider['conf']);
+            $this->assertTrue($config->update($conf));
+
+            PluginEscaladeConfig::loadInSession();
+
+            $t_id = $ticket->add([
+                'name' => 'Assign Cat Escalation Test',
+                'content' => 'content',
+                'itilcategories_id' => $itil_category1_id,
+            ]);
+            $this->assertGreaterThan(0, $t_id);
+            $count_user1_assign_add = $provider['conf']['remove_tech'] === 0 ? 1 : 0;
+            $this->assertEquals($count_user1_assign_add, count($ticket_user->find(['tickets_id' => $t_id])));
+            $this->assertEquals($count_user1_assign_add, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID()])));
+            $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID()])));
+            $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id])));
+            $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $t_id, 'groups_id' => $group1->getID()])));
+            $this->assertEquals(0, count($ticket_group->find(['tickets_id' => $t_id, 'groups_id' => $group2->getID()])));
+
+            $ticket->getFromDB($t_id);
+
+            $success = $ticket->update([
+                'id' => $t_id,
+                'itilcategories_id' => $itil_category2_id,
+            ]);
+            $this->assertTrue($success);
+
+            $this->assertEquals($provider['expected']['users'], count($ticket_user->find(['tickets_id' => $t_id])));
+            $this->assertEquals($provider['expected']['user_1_is_assign'], count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user1->getID()])));
+            $this->assertEquals($provider['expected']['user_2_is_assign'], count($ticket_user->find(['tickets_id' => $t_id, 'users_id' => $user2->getID()])));
+            $this->assertEquals($provider['expected']['groups'], count($ticket_group->find(['tickets_id' => $t_id])));
+            $this->assertEquals($provider['expected']['group_1_is_assign'], count($ticket_group->find(['tickets_id' => $t_id, 'groups_id' => $group1->getID()])));
+            $this->assertEquals($provider['expected']['group_2_is_assign'], count($ticket_group->find(['tickets_id' => $t_id, 'groups_id' => $group2->getID()])));
+        }
     }
 }

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -554,10 +554,10 @@ final class TicketTest extends EscaladeTestCase
     {
         yield [
             'conf' => [
-                'remove_tech'  => 0,
-                'remove_group' => 0,
+                'remove_tech'             => 0,
+                'remove_group'            => 0,
                 'reassign_group_from_cat' => 0,
-                'reassign_tech_from_cat' => 0,
+                'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
                 'users' => 1,
@@ -571,10 +571,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 0,
-                'remove_group' => 0,
+                'remove_tech'             => 0,
+                'remove_group'            => 0,
                 'reassign_group_from_cat' => 0,
-                'reassign_tech_from_cat' => 1,
+                'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
                 'users' => 2,
@@ -588,10 +588,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 0,
-                'remove_group' => 0,
+                'remove_tech'             => 0,
+                'remove_group'            => 0,
                 'reassign_group_from_cat' => 1,
-                'reassign_tech_from_cat' => 0,
+                'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
                 'users' => 1,
@@ -605,10 +605,44 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 0,
-                'remove_group' => 1,
+                'remove_tech'             => 0,
+                'remove_group'            => 0,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat'  => 1,
+            ],
+            'expected' => [
+                'users' => 2,
+                'groups' => 2,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'             => 0,
+                'remove_group'            => 1,
                 'reassign_group_from_cat' => 0,
-                'reassign_tech_from_cat' => 1,
+                'reassign_tech_from_cat'  => 0,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 1,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'             => 0,
+                'remove_group'            => 1,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
                 'users' => 2,
@@ -622,10 +656,27 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 0,
-                'remove_group' => 1,
+                'remove_tech'             => 0,
+                'remove_group'            => 1,
                 'reassign_group_from_cat' => 1,
-                'reassign_tech_from_cat' => 1,
+                'reassign_tech_from_cat'  => 0,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 1,
+                'user_1_is_assign' => 1,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 0,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'             => 0,
+                'remove_group'            => 1,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
                 'users' => 2,
@@ -639,10 +690,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 1,
-                'remove_group' => 0,
+                'remove_tech'             => 1,
+                'remove_group'            => 0,
                 'reassign_group_from_cat' => 0,
-                'reassign_tech_from_cat' => 0,
+                'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
                 'users' => 0,
@@ -656,10 +707,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 1,
-                'remove_group' => 0,
+                'remove_tech'             => 1,
+                'remove_group'            => 0,
                 'reassign_group_from_cat' => 0,
-                'reassign_tech_from_cat' => 1,
+                'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
                 'users' => 1,
@@ -673,10 +724,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 1,
-                'remove_group' => 0,
+                'remove_tech'             => 1,
+                'remove_group'            => 0,
                 'reassign_group_from_cat' => 1,
-                'reassign_tech_from_cat' => 0,
+                'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
                 'users' => 0,
@@ -690,10 +741,44 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 1,
-                'remove_group' => 1,
+                'remove_tech'             => 1,
+                'remove_group'            => 0,
+                'reassign_group_from_cat' => 1,
+                'reassign_tech_from_cat'  => 1,
+            ],
+            'expected' => [
+                'users' => 1,
+                'groups' => 2,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 1,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 1,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'             => 1,
+                'remove_group'            => 1,
                 'reassign_group_from_cat' => 0,
-                'reassign_tech_from_cat' => 1,
+                'reassign_tech_from_cat'  => 0,
+            ],
+            'expected' => [
+                'users' => 0,
+                'groups' => 1,
+                'user_1_is_assign' => 0,
+                'user_2_is_assign' => 0,
+                'group_1_is_assign' => 1,
+                'group_2_is_assign' => 0,
+            ],
+        ];
+
+        yield [
+            'conf' => [
+                'remove_tech'             => 1,
+                'remove_group'            => 1,
+                'reassign_group_from_cat' => 0,
+                'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
                 'users' => 1,
@@ -707,10 +792,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 1,
-                'remove_group' => 1,
+                'remove_tech'             => 1,
+                'remove_group'            => 1,
                 'reassign_group_from_cat' => 1,
-                'reassign_tech_from_cat' => 0,
+                'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
                 'users' => 0,
@@ -724,10 +809,10 @@ final class TicketTest extends EscaladeTestCase
 
         yield [
             'conf' => [
-                'remove_tech'  => 1,
-                'remove_group' => 1,
+                'remove_tech'             => 1,
+                'remove_group'            => 1,
                 'reassign_group_from_cat' => 1,
-                'reassign_tech_from_cat' => 1,
+                'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
                 'users' => 1,

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -897,16 +897,11 @@ final class TicketTest extends EscaladeTestCase
         );
 
         foreach ($this->testAssignGroupToTicketWithCategoryProvider() as $provider) {
-            $config = new PluginEscaladeConfig();
-            $conf = $config->find();
-            $conf = reset($conf);
-            $config->getFromDB($conf['id']);
-            $this->assertGreaterThan(0, $conf['id']);
             // Update escalade config
             $this->updateItem(
                 PluginEscaladeConfig::class,
-                $conf['id'],
-                array_merge($conf, $provider['conf']),
+                1,
+                $provider['conf'],
             );
 
             PluginEscaladeConfig::loadInSession();

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -560,8 +560,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
@@ -577,8 +575,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 2,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 1,
@@ -594,8 +590,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 2,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
@@ -611,8 +605,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 2,
-                'groups' => 2,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 1,
@@ -628,8 +620,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
@@ -645,8 +635,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 2,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 1,
@@ -662,8 +650,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 0,
@@ -679,8 +665,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 2,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 0,
@@ -696,8 +680,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
@@ -713,8 +695,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 0,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 1,
@@ -730,8 +710,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 0,
-                'groups' => 2,
                 'user_1_is_assign' => 0,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
@@ -747,8 +725,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 2,
                 'user_1_is_assign' => 0,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 1,
@@ -764,8 +740,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 1,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 1,
@@ -781,8 +755,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 0,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 1,
@@ -798,8 +770,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 0,
             ],
             'expected' => [
-                'users' => 0,
-                'groups' => 1,
                 'user_1_is_assign' => 0,
                 'user_2_is_assign' => 0,
                 'group_1_is_assign' => 0,
@@ -815,8 +785,6 @@ final class TicketTest extends EscaladeTestCase
                 'reassign_tech_from_cat'  => 1,
             ],
             'expected' => [
-                'users' => 1,
-                'groups' => 1,
                 'user_1_is_assign' => 0,
                 'user_2_is_assign' => 1,
                 'group_1_is_assign' => 0,
@@ -930,10 +898,8 @@ final class TicketTest extends EscaladeTestCase
                 ],
             );
 
-            $this->assertEquals($provider['expected']['users'], count($ticket_user->find(['tickets_id' => $ticket->getID()])));
             $this->assertEquals($provider['expected']['user_1_is_assign'], count($ticket_user->find(['tickets_id' => $ticket->getID(), 'users_id' => $user1->getID()])));
             $this->assertEquals($provider['expected']['user_2_is_assign'], count($ticket_user->find(['tickets_id' => $ticket->getID(), 'users_id' => $user2->getID()])));
-            $this->assertEquals($provider['expected']['groups'], count($ticket_group->find(['tickets_id' => $ticket->getID()])));
             $this->assertEquals($provider['expected']['group_1_is_assign'], count($ticket_group->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group1->getID()])));
             $this->assertEquals($provider['expected']['group_2_is_assign'], count($ticket_group->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID()])));
         }

--- a/tests/units/UserEscalationTest.php
+++ b/tests/units/UserEscalationTest.php
@@ -171,9 +171,16 @@ final class UserEscalationTest extends EscaladeTestCase
         $conf = reset($conf);
         $config->getFromDB($conf['id']);
         $this->assertGreaterThan(0, $conf['id']);
-        $this->assertTrue($config->update([
-            'remove_tech' => 1
-        ] + $conf));
+        $this->updateItem(
+            PluginEscaladeConfig::class,
+            $conf['id'],
+            array_merge(
+                $conf,
+                [
+                    'remove_tech' => 1
+                ]
+            ),
+        );
 
         PluginEscaladeConfig::loadInSession();
 
@@ -185,36 +192,40 @@ final class UserEscalationTest extends EscaladeTestCase
         $user2->getFromDBbyName('tech');
         $this->assertGreaterThan(0, $user2->getID());
 
-        $ticket = new \Ticket();
-        $t_id = $ticket->add([
-            'name' => 'Task User change Escalation Test',
-            'content' => '',
-        ]);
+        $ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name' => 'Task User change Escalation Test',
+                'content' => '',
+            ]
+        );
 
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
         // Update ticket with just one user
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_actors' => [
                     'assign' => [
                         [
                             'items_id' => $user1->getID(),
                             'itemtype' => 'User'
-                        ]
+                        ],
                     ],
                 ],
             ]
-        ));
+        );
 
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
 
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_actors' => [
                     'assign' => [
                         [
@@ -228,23 +239,31 @@ final class UserEscalationTest extends EscaladeTestCase
                     ],
                 ],
             ]
-        ));
+        );
 
         // Check if user is disassociated to this ticket and the group replace it
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
         // Disable remove tech options
-        $this->assertTrue($config->update([
-            'remove_tech' => 0
-        ] + $conf));
+        $this->updateItem(
+            PluginEscaladeConfig::class,
+            $conf['id'],
+            array_merge(
+                $conf,
+                [
+                    'remove_tech' => 0
+                ]
+            ),
+        );
 
         PluginEscaladeConfig::loadInSession();
 
         // Add a user and remove the group from this ticket
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_actors' => [
                     'assign' => [
                         [
@@ -254,15 +273,16 @@ final class UserEscalationTest extends EscaladeTestCase
                     ],
                 ],
             ]
-        ));
+        );
 
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
-        // Add a group to the ticket
-        $this->assertTrue($ticket->update(
+         // Add a group to the ticket
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_actors' => [
                     'assign' => [
                         [
@@ -276,11 +296,11 @@ final class UserEscalationTest extends EscaladeTestCase
                     ],
                 ],
             ]
-        ));
+        );
 
         // Check if the user and group are associated to this ticket
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
     }
 
     public function testUserEscalationRemovesTechnicianWhenUserIsAutoAssign()
@@ -292,9 +312,16 @@ final class UserEscalationTest extends EscaladeTestCase
         $conf = reset($conf);
         $config->getFromDB($conf['id']);
         $this->assertGreaterThan(0, $conf['id']);
-        $this->assertTrue($config->update([
-            'remove_tech' => 1
-        ] + $conf));
+        $this->updateItem(
+            PluginEscaladeConfig::class,
+            $conf['id'],
+            array_merge(
+                $conf,
+                [
+                    'remove_tech' => 1
+                ]
+            ),
+        );
 
         PluginEscaladeConfig::loadInSession();
 
@@ -306,19 +333,22 @@ final class UserEscalationTest extends EscaladeTestCase
         $user2->getFromDBbyName('glpi');
         $this->assertGreaterThan(0, $user2->getID());
 
-        $ticket = new \Ticket();
-        $t_id = $ticket->add([
-            'name' => 'Task User change Escalation Test',
-            'content' => '',
-        ]);
+        $ticket = $this->createItem(
+            \Ticket::class,
+            [
+                'name' => 'Task User change Escalation Test',
+                'content' => '',
+            ]
+        );
 
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
         // Update ticket with just one user
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_actors' => [
                     'assign' => [
                         [
@@ -328,39 +358,48 @@ final class UserEscalationTest extends EscaladeTestCase
                     ],
                 ],
             ]
-        ));
+        );
 
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
 
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_itil_assign' => [
                     '_type' => "user",
                     'users_id' => \Session::getLoginUserID(),
                     'use_notification' => 1,
                 ]
             ]
-        ));
+        );
 
         // Check if user is disassociated to this ticket and the group replace it
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
         // Disable remove tech options
-        $this->assertTrue($config->update([
-            'remove_tech' => 0
-        ] + $conf));
+        $this->updateItem(
+            PluginEscaladeConfig::class,
+            $conf['id'],
+            array_merge(
+                $conf,
+                [
+                    'remove_tech' => 0
+                ]
+            ),
+        );
 
         PluginEscaladeConfig::loadInSession();
 
         // Add a user and remove the group from this ticket
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_actors' => [
                     'assign' => [
                         [
@@ -370,26 +409,27 @@ final class UserEscalationTest extends EscaladeTestCase
                     ],
                 ],
             ]
-        ));
+        );
 
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
 
         // Assign me to the ticket
-        $this->assertTrue($ticket->update(
+        $this->updateItem(
+            \Ticket::class,
+            $ticket->getID(),
             [
-                'id' => $t_id,
                 '_itil_assign' => [
                     '_type' => "user",
                     'users_id' => \Session::getLoginUserID(),
                 ]
             ]
-        ));
+        );
 
         // Check if the user and group are associated to this ticket
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN])));
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $t_id, 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
+        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
     }
 }

--- a/tests/units/UserEscalationTest.php
+++ b/tests/units/UserEscalationTest.php
@@ -166,20 +166,12 @@ final class UserEscalationTest extends EscaladeTestCase
     {
         $this->login();
 
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
         $this->updateItem(
             PluginEscaladeConfig::class,
-            $conf['id'],
-            array_merge(
-                $conf,
-                [
-                    'remove_tech' => 1
-                ]
-            ),
+            1,
+            [
+                'remove_tech' => 1
+            ]
         );
 
         PluginEscaladeConfig::loadInSession();
@@ -248,13 +240,10 @@ final class UserEscalationTest extends EscaladeTestCase
         // Disable remove tech options
         $this->updateItem(
             PluginEscaladeConfig::class,
-            $conf['id'],
-            array_merge(
-                $conf,
-                [
-                    'remove_tech' => 0
-                ]
-            ),
+            1,
+            [
+                'remove_tech' => 0
+            ]
         );
 
         PluginEscaladeConfig::loadInSession();
@@ -307,20 +296,12 @@ final class UserEscalationTest extends EscaladeTestCase
     {
         $this->login();
 
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
         $this->updateItem(
             PluginEscaladeConfig::class,
-            $conf['id'],
-            array_merge(
-                $conf,
-                [
-                    'remove_tech' => 1
-                ]
-            ),
+            1,
+            [
+                'remove_tech' => 1
+            ]
         );
 
         PluginEscaladeConfig::loadInSession();
@@ -384,13 +365,10 @@ final class UserEscalationTest extends EscaladeTestCase
         // Disable remove tech options
         $this->updateItem(
             PluginEscaladeConfig::class,
-            $conf['id'],
-            array_merge(
-                $conf,
-                [
-                    'remove_tech' => 0
-                ]
-            ),
+            1,
+            [
+                'remove_tech' => 0
+            ]
         );
 
         PluginEscaladeConfig::loadInSession();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37334
- If the option "remove a technician during an escalation" is activated and no group was assigned to the ticket, the technicians were not deleted. It's the same problem for "Assign Me" button.

## Screenshots (if appropriate):

Before escalation
![Capture d’écran du 2025-04-11 11-30-53](https://github.com/user-attachments/assets/80c3df48-3f59-41f5-87a3-02840d7c18a3)

After escalation
![Capture d’écran du 2025-04-11 11-31-44](https://github.com/user-attachments/assets/77a4ec38-54ce-4a3b-a423-c196b130fae8)



