### PR TITLE
fix(ruleticket): Escalate timeline button execute RuleTicket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unrelease] -
 
+- Fix Escalate timeline button execute RuleTicket
+
 
 ## [2.9.13] - 2025-03-31
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -63,15 +63,22 @@ if (isset($_POST['escalate'])) {
             ]);
         }
 
-        $ticket_group = new Group_Ticket();
+        // Update the ticket with actor data in order to execute the necessary rules
+        $_form_object = [
+            '_do_not_compute_status' => true,
+        ];
+        if ($_SESSION['plugins']['escalade']['config']['ticket_last_status'] != -1) {
+            $_form_object['status'] = $_SESSION['plugins']['escalade']['config']['ticket_last_status'];
+        }
+        $updates_ticket = new Ticket();
         if (
-            $ticket_group->add(
-                [
-                    'tickets_id'                    => $tickets_id,
-                    'groups_id'                     => $group_id,
-                    'type'                          => CommonITILActor::ASSIGN,
-                    '_disablenotif'                 => true,
-                    '_plugin_escalade_no_history'   => true,
+            $updates_ticket->update(
+                $_POST['ticket_details'] + [
+                    '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
+                    '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+                    'actortype' => CommonITILActor::ASSIGN,
+                    'groups_id' => $group_id,
+                    '_form_object' => $_form_object,
                 ]
             )
         ) {

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -82,20 +82,6 @@ if (isset($_POST['escalate'])) {
                 ]
             )
         ) {
-            if ($_SESSION['glpi_plugins']['escalade']['config']['task_history']) {
-                $task = new TicketTask();
-                $task->add(
-                    [
-                        'tickets_id' => $tickets_id,
-                        'is_private' => true,
-                        'state'      => Planning::INFO,
-                        // Sanitize before merging with $_POST['comment'] which is already sanitized
-                        'content'    => Sanitizer::sanitize(
-                            '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />'
-                        ) . $_POST['comment']
-                    ]
-                );
-            }
 
             //notified only the last group assigned
             $ticket = new Ticket();

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -82,7 +82,6 @@ if (isset($_POST['escalate'])) {
                 ]
             )
         ) {
-
             //notified only the last group assigned
             $ticket = new Ticket();
             $ticket->getFromDB($tickets_id);

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -390,11 +390,14 @@ class PluginEscaladeTicket
             $group->getFromDB($groups_id);
 
             $task = new TicketTask();
+            $comment = $_POST['comment'] ?? '';
             $task->add([
                 'tickets_id' => $tickets_id,
                 'is_private' => true,
                 'state'      => Planning::INFO,
-                'content'    => Toolbox::addslashes_deep(sprintf(__("Escalation to the group %s.", "escalade"), $group->getName())),
+                'content'    => Sanitizer::sanitize(
+                    '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />'
+                    ) . $comment,
             ]);
         }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -599,6 +599,7 @@ class PluginEscaladeTicket
         if (
             $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] != 0
             && $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] != 0
+            && isset($_SESSION['plugin_escalade']['ticket_creation'])
             && $_SESSION['plugin_escalade']['ticket_creation']
         ) {
             return;

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -397,7 +397,7 @@ class PluginEscaladeTicket
                 'state'      => Planning::INFO,
                 'content'    => Sanitizer::sanitize(
                     '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />'
-                    ) . $comment,
+                ) . $comment,
             ]);
         }
 

--- a/tests/EscaladeTestCase.php
+++ b/tests/EscaladeTestCase.php
@@ -37,7 +37,6 @@ use DbTestCase;
 
 abstract class EscaladeTestCase extends DbTestCase
 {
-
     protected function login(
         string $user_name = TU_USER,
         string $user_pass = TU_PASS,

--- a/tests/EscaladeTestCase.php
+++ b/tests/EscaladeTestCase.php
@@ -33,22 +33,10 @@ namespace GlpiPlugin\Escalade\Tests;
 use Auth;
 use PHPUnit\Framework\TestCase;
 use Session;
+use DbTestCase;
 
-abstract class EscaladeTestCase extends TestCase
+abstract class EscaladeTestCase extends DbTestCase
 {
-    protected function setUp(): void
-    {
-        global $DB;
-        $DB->beginTransaction();
-        parent::setUp();
-    }
-
-    protected function tearDown(): void
-    {
-        global $DB;
-        $DB->rollback();
-        parent::tearDown();
-    }
 
     protected function login(
         string $user_name = TU_USER,

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,7 +28,14 @@
  * -------------------------------------------------------------------------
  */
 
+use Glpi\Cache\CacheManager;
+use Glpi\Cache\SimpleCache;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
 global $CFG_GLPI, $PLUGIN_HOOKS;
+
+ini_set('display_errors', 'On');
+error_reporting(E_ALL);
 
 define('GLPI_ROOT', dirname(__DIR__, 3));
 define('GLPI_LOG_DIR', GLPI_ROOT . '/files/_logs');
@@ -37,4 +44,41 @@ define('TU_USER', 'glpi');
 define('TU_PASS', 'glpi');
 define('GLPI_LOG_LVL', 'DEBUG');
 
+include(GLPI_ROOT . "/inc/based_config.php");
+
+if (!file_exists(GLPI_CONFIG_DIR . '/config_db.php')) {
+    die("\nConfiguration file for tests not found\n\nrun: bin/console glpi:database:install --config-dir=tests/config ...\n\n");
+}
+
+// Create subdirectories of GLPI_VAR_DIR based on defined constants
+foreach (get_defined_constants() as $constant_name => $constant_value) {
+    if (
+        preg_match('/^GLPI_[\w]+_DIR$/', $constant_name)
+        && preg_match('/^' . preg_quote(GLPI_VAR_DIR, '/') . '\//', $constant_value)
+    ) {
+        is_dir($constant_value) or mkdir($constant_value, 0755, true);
+    }
+}
+
+//init cache
+if (file_exists(GLPI_CONFIG_DIR . DIRECTORY_SEPARATOR . CacheManager::CONFIG_FILENAME)) {
+    // Use configured cache for cache tests
+    $cache_manager = new CacheManager();
+    $GLPI_CACHE = $cache_manager->getCoreCacheInstance();
+} else {
+    // Use "in-memory" cache for other tests
+    $GLPI_CACHE = new SimpleCache(new ArrayAdapter());
+}
+
 require GLPI_ROOT . '/inc/includes.php';
+include_once GLPI_ROOT . '/phpunit/GLPITestCase.php';
+include_once GLPI_ROOT . '/phpunit/DbTestCase.php';
+plugin_init_escalade();
+
+if (!file_exists(GLPI_LOG_DIR . '/php-errors.log')) {
+    file_put_contents(GLPI_LOG_DIR . '/php-errors.log', '');
+}
+
+if (!file_exists(GLPI_LOG_DIR . '/sql-errors.log')) {
+    file_put_contents(GLPI_LOG_DIR . '/sql-errors.log', '');
+}

--- a/tests/units/TaskMessageTest.php
+++ b/tests/units/TaskMessageTest.php
@@ -51,6 +51,14 @@ final class TaskMessageTest extends EscaladeTestCase
 
     public function testGroupEscalation()
     {
+        $this->login();
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+        PluginEscaladeConfig::loadInSession();
+
         $ticket = new \Ticket();
         $ticket->add([
             'name' => 'Escalation Test',
@@ -119,6 +127,14 @@ final class TaskMessageTest extends EscaladeTestCase
 
     public function testTaskGroupEscalation()
     {
+        $this->login();
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+        PluginEscaladeConfig::loadInSession();
+
         $ticket = new \Ticket();
         $ticket->add([
             'name' => 'Task Group Escalation Test',

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -294,4 +294,81 @@ final class TicketTest extends EscaladeTestCase
         }
         $this->assertTrue($found_new_group, "New group should be assigned after successful escalation");
     }
+
+    public function testEscalateButtonShouldTriggerGroupEscalationAndExecuteRuleOnTicket()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        PluginEscaladeConfig::loadInSession();
+
+        $group_observer = new \Group();
+        $group_observer_id = $group_observer->add([
+            'name' => 'Group Observer',
+            'entities_id' => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->assertGreaterThan(0, $group_observer_id);
+
+        $group_tech = new \Group();
+        $group_tech_id = $group_tech->add([
+            'name' => 'Group tech',
+            'entities_id' => 0,
+            'is_recursive' => 1,
+        ]);
+        $this->assertGreaterThan(0, $group_tech_id);
+
+        $rule = new \Rule();
+        $rule_id = $rule->add([
+            'name' => 'Add RuleTicket',
+            'sub_type' => 'RuleTicket',
+            'match' => 'AND',
+            'is_active' => 1,
+            'condition' => 2,
+        ]);
+        $this->assertGreaterThan(0, $rule_id);
+
+        $rule_action = new \RuleAction();
+        $rule_action_id = $rule_action->add([
+            'rules_id' => $rule_id,
+            'action_type' => 'assign',
+            'field' => '_groups_id_observer',
+            'value' => $group_observer_id,
+        ]);
+        $this->assertGreaterThan(0, $rule_action_id);
+
+        $rule_criteria = new \RuleCriteria();
+        $rule_criteria_id = $rule_criteria->add([
+            'rules_id' => $rule_id,
+            'criteria' => '_groups_id_assign',
+            'condition' => 0,
+            'pattern' => $group_tech_id,
+        ]);
+        $this->assertGreaterThan(0, $rule_criteria_id);
+
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name' => 'Test ticket for escalation',
+            'content' => 'Content for test ticket',
+        ]);
+        $this->assertGreaterThan(0, $ticket_id);
+
+        $group_ticket = new \Group_Ticket();
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_tech->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_observer->getID(), 'type' => \CommonITILActor::OBSERVER])));
+
+        $ticket_update = $ticket->update([
+            'id' => $ticket_id,
+            '_groups_id_assign' => [$group_tech_id],
+        ]);
+        $this->assertTrue($ticket_update);
+
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_tech->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_observer->getID(), 'type' => \CommonITILActor::OBSERVER])));
+    }
 }

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -307,68 +307,56 @@ final class TicketTest extends EscaladeTestCase
 
         PluginEscaladeConfig::loadInSession();
 
-        $group_observer = new \Group();
-        $group_observer_id = $group_observer->add([
+        $group_observer_id = $this->createItem(\Group::class, [
             'name' => 'Group Observer',
             'entities_id' => 0,
             'is_recursive' => 1,
-        ]);
-        $this->assertGreaterThan(0, $group_observer_id);
+        ])->getID();
 
-        $group_tech = new \Group();
-        $group_tech_id = $group_tech->add([
+        $group_tech_id = $this->createItem(\Group::class, [
             'name' => 'Group tech',
             'entities_id' => 0,
             'is_recursive' => 1,
-        ]);
-        $this->assertGreaterThan(0, $group_tech_id);
+        ])->getID();
 
-        $rule = new \Rule();
-        $rule_id = $rule->add([
+        $rule_id = $this->createItem(\Rule::class, [
             'name' => 'Add RuleTicket',
             'sub_type' => 'RuleTicket',
             'match' => 'AND',
             'is_active' => 1,
             'condition' => 2,
-        ]);
-        $this->assertGreaterThan(0, $rule_id);
+        ])->getID();
 
-        $rule_action = new \RuleAction();
-        $rule_action_id = $rule_action->add([
+        $this->createItem(\RuleAction::class, [
             'rules_id' => $rule_id,
             'action_type' => 'assign',
             'field' => '_groups_id_observer',
             'value' => $group_observer_id,
         ]);
-        $this->assertGreaterThan(0, $rule_action_id);
 
-        $rule_criteria = new \RuleCriteria();
-        $rule_criteria_id = $rule_criteria->add([
+        $this->createItem(\RuleCriteria::class, [
             'rules_id' => $rule_id,
             'criteria' => '_groups_id_assign',
             'condition' => 0,
             'pattern' => $group_tech_id,
         ]);
-        $this->assertGreaterThan(0, $rule_criteria_id);
 
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem(\Ticket::class, [
             'name' => 'Test ticket for escalation',
             'content' => 'Content for test ticket',
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
 
         $group_ticket = new \Group_Ticket();
-        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_tech->getID(), 'type' => \CommonITILActor::ASSIGN])));
-        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_observer->getID(), 'type' => \CommonITILActor::OBSERVER])));
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group_tech_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group_observer_id, 'type' => \CommonITILActor::OBSERVER])));
 
         $ticket_update = $ticket->update([
-            'id' => $ticket_id,
+            'id' => $ticket->getID(),
             '_groups_id_assign' => [$group_tech_id],
         ]);
         $this->assertTrue($ticket_update);
 
-        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_tech->getID(), 'type' => \CommonITILActor::ASSIGN])));
-        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_observer->getID(), 'type' => \CommonITILActor::OBSERVER])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group_tech_id, 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group_observer_id, 'type' => \CommonITILActor::OBSERVER])));
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37622
- If the user uses the timeline button to escalate a group, ticket rules that take into account the technician field as a launch criterion are not executed.
