### PR TITLE
fix(ticket): assign myself button doesn't change ticket status when ticket_last_status option is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fix `show_history` option when using the `Escalate` button.
 - Fix `use_assign_user_group` option wich delete assing users
+- Fix `ticket_last_status` option when using the `Associate myself` button.
 
 ## [2.9.12] - 2025-03-20
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -46,12 +46,7 @@ class PluginEscaladeTicket
                 return false;
             }
         }
-        if (
-            isset($item->input['_itil_assign'])
-            && $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE
-        ) {
-            $item->input['_do_not_compute_status'] = true;
-        }
+
         $old_groups = [];
 
         // Get actual actors for the ticket

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -448,7 +448,7 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID(), 'type' => \CommonITILActor::ASSIGN])));
     }
 
-        public function testStatusTicketOption()
+    public function testStatusTicketOption()
     {
         $this->login();
 
@@ -478,7 +478,7 @@ final class TicketTest extends EscaladeTestCase
             'is_recursive' => 1,
         ]);
 
-                $ticket = $this->createItem(\Ticket::class, [
+        $ticket = $this->createItem(\Ticket::class, [
             'name' => 'Test ticket',
             'content' => 'Content',
         ]);

--- a/tests/units/TicketTest.php
+++ b/tests/units/TicketTest.php
@@ -447,4 +447,105 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group1->getID(), 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID(), 'type' => \CommonITILActor::ASSIGN])));
     }
+
+        public function testStatusTicketOption()
+    {
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+        $this->assertTrue($config->update([
+            'ticket_last_status' => \CommonITILObject::INCOMING,
+            'remove_tech' => 0,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        $user1 = new \User();
+        $user1->getFromDBbyName('tech');
+        $this->assertGreaterThan(0, $user1->getID());
+
+        $user2 = new \User();
+        $user2->getFromDBbyName('glpi');
+        $this->assertGreaterThan(0, $user2->getID());
+
+        $group_tech = $this->createItem(\Group::class, [
+            'name' => 'Group tech',
+            'entities_id' => 0,
+            'is_recursive' => 1,
+        ]);
+
+                $ticket = $this->createItem(\Ticket::class, [
+            'name' => 'Test ticket',
+            'content' => 'Content',
+        ]);
+
+        $this->assertEquals(\CommonITILObject::INCOMING, $ticket->fields['status']);
+
+        $group_ticket = new \Group_Ticket();
+        $user_ticket = new \Ticket_User();
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+
+        $this->assertTrue(
+            $ticket->update([
+                'id' => $ticket->getID(),
+                '_actors' => [
+                    'assign' => [
+                        [
+                            'items_id' => $user1->getID(),
+                            'itemtype' => 'User'
+                        ],
+                    ],
+                ],
+            ])
+        );
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+        $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
+
+        $this->assertTrue(
+            $ticket->update([
+                'id' => $ticket->getID(),
+                '_actors' => [
+                    'assign' => [
+                        [
+                            'items_id' => $user1->getID(),
+                            'itemtype' => 'User'
+                        ],
+                        [
+                            'items_id' => $group_tech->getID(),
+                            'itemtype' => 'Group'
+                        ],
+                    ],
+                ],
+            ])
+        );
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'groups_id' => $group_tech->getID()])));
+        $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+        $this->assertEquals(\CommonITILObject::INCOMING, $ticket->fields['status']);
+
+        $this->assertTrue(
+            $ticket->update([
+                'id' => $ticket->getID(),
+                '_itil_assign' => [
+                    '_type' => "user",
+                    'users_id' => $user2->getID(),
+                    'use_notification' => 1,
+                ]
+            ])
+        );
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'groups_id' => $group_tech->getID()])));
+        $this->assertEquals(2, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user1->getID()])));
+        $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
+        $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
+    }
 }


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37728
- If the ticket_last_status option is enabled in the escalation plugin configuration, and the user assigns himself to a ticket using the “Associate myself” button, the ticket status is modified to that configured. This behavior was not present in GLPI 9.5 and is also not present if the user is assigned to the ticket via the actor drop-down list.
