### PR TITLE
fix(ticket): update ticket without itilcategory change group

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -162,7 +162,7 @@ class PluginEscaladeTicket
         }
 
         //ticket qualification on cat change
-        if (isset($item->input['itilcategories_id'])) {
+        if (isset($item->updates['itilcategories_id'])) {
             self::qualification($item);
         }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37838
- If a category is assigned to a ticket and this category has a responsible group, the ticket update will automatically assign this responsible group even if the category has not been updated and the technician group has been modified.
