### PR TITLE
Fix - Duplicate notification sent to old group during escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+- Fix duplicate notification sent to old group during escalation
 - Fix 8 warnings in the `php-errors.log` file
 
 ## [2.9.14] - 2025-05-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
-- Fix duplicate notification sent to old group during escalation
+- Fix duplicate notifications being sent during escalation by implementing two additional targets.
 - Fix 8 warnings in the `php-errors.log` file
 
 ## [2.9.14] - 2025-05-28

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -78,7 +78,7 @@ if (isset($_POST['escalate'])) {
                 'actortype' => CommonITILActor::ASSIGN,
                 'groups_id' => $group_id,
                 '_form_object' => $_form_object,
-            ]
+            ],
         );
     }
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -71,24 +71,15 @@ if (isset($_POST['escalate'])) {
             $_form_object['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
         }
         $updates_ticket = new Ticket();
-        if (
-            $updates_ticket->update(
-                $_POST['ticket_details'] + [
-                    '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
-                    '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
-                    'actortype' => CommonITILActor::ASSIGN,
-                    'groups_id' => $group_id,
-                    '_form_object' => $_form_object,
-                ]
-            )
-        ) {
-            //notified only the last group assigned
-            $ticket = new Ticket();
-            $ticket->getFromDB($tickets_id);
-
-            $event = "assign_group";
-            NotificationEvent::raiseEvent($event, $ticket);
-        }
+        $updates_ticket->update(
+            $_POST['ticket_details'] + [
+                '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
+                '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+                'actortype' => CommonITILActor::ASSIGN,
+                'groups_id' => $group_id,
+                '_form_object' => $_form_object,
+            ]
+        );
     }
 
     $track = new Ticket();

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -207,21 +207,21 @@ class PluginEscaladeNotification
             $item = $target->obj;
 
             switch ($target->data['items_id']) {
-                    // Only last escalation group
-                    case self::NTRGT_TICKET_LAST_ESCALADE_GROUP: // phpcs:ignore
-                        $manager = 0;
-                    case self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER:
-                        if (!isset($manager)) {
-                            $manager = 1;
-                        }
-                        $history = new PluginEscaladeHistory();
-                        // Retrieve only the last escalation history
-                        foreach ($history->find(['tickets_id' => $item->getID()], ['id DESC'], 1) as $found_history) {
-                            // We only process the first entry (the most recent)
-                            $target->addForGroup($manager, $found_history['groups_id']);
-                            break;
-                        }
+                // Only last escalation group
+                case self::NTRGT_TICKET_LAST_ESCALADE_GROUP: // phpcs:ignore
+                    $manager = 0;
+                case self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER:
+                    if (!isset($manager)) {
+                        $manager = 1;
+                    }
+                    $history = new PluginEscaladeHistory();
+                    // Retrieve only the last escalation history
+                    foreach ($history->find(['tickets_id' => $item->getID()], ['id DESC'], 1) as $found_history) {
+                        // We only process the first entry (the most recent)
+                        $target->addForGroup($manager, $found_history['groups_id']);
                         break;
+                    }
+                    break;
             }
         }
     }

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -113,14 +113,14 @@ class PluginEscaladeNotification
                 Notification::AUTHOR,
                 __('Requester user of the task/reminder', 'escalade'),
             );
-        } else if ($target instanceof NotificationTargetCommonITILObject) {
+        } elseif ($target instanceof NotificationTargetCommonITILObject) {
             $target->addTarget(
                 self::NTRGT_TICKET_LAST_ESCALADE_GROUP,
-                __('Last group escalated in the ticket', 'escalade')
+                __('Last group escalated in the ticket', 'escalade'),
             );
             $target->addTarget(
                 self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER,
-                __('Manager of last group escalated in the ticket', 'escalade')
+                __('Manager of last group escalated in the ticket', 'escalade'),
             );
         }
     }
@@ -211,13 +211,14 @@ class PluginEscaladeNotification
                         break;
                 }
             }
-        } else if ($target instanceof NotificationTargetCommonITILObject) {
+        } elseif ($target instanceof NotificationTargetCommonITILObject) {
             $item = $target->obj;
 
             switch ($target->data['items_id']) {
                 // Only last escalation group
                 case self::NTRGT_TICKET_LAST_ESCALADE_GROUP:
                     $manager = 0;
+                    // no break
                 case self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER:
                     if (!isset($manager)) {
                         $manager = 1;

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -216,7 +216,7 @@ class PluginEscaladeNotification
 
             switch ($target->data['items_id']) {
                 // Only last escalation group
-                case self::NTRGT_TICKET_LAST_ESCALADE_GROUP: // phpcs:ignore
+                case self::NTRGT_TICKET_LAST_ESCALADE_GROUP:
                     $manager = 0;
                 case self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER:
                     if (!isset($manager)) {

--- a/inc/notification.class.php
+++ b/inc/notification.class.php
@@ -43,6 +43,8 @@ class PluginEscaladeNotification
 
     const NTRGT_TICKET_ESCALADE_GROUP          = 457951;
     const NTRGT_TICKET_ESCALADE_GROUP_MANAGER  = 457952;
+    const NTRGT_TICKET_LAST_ESCALADE_GROUP     = 457953;
+    const NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER = 457954;
 
    /**
     * Add additional targets (recipient) to Glpi Notification 'planningrecall'
@@ -110,6 +112,15 @@ class PluginEscaladeNotification
             $target->addTarget(
                 Notification::AUTHOR,
                 __('Requester user of the task/reminder', 'escalade')
+            );
+        } else if ($target instanceof NotificationTargetCommonITILObject) {
+            $target->addTarget(
+                self::NTRGT_TICKET_LAST_ESCALADE_GROUP,
+                __('Last group escalated in the ticket', 'escalade')
+            );
+            $target->addTarget(
+                self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER,
+                __('Manager of last group escalated in the ticket', 'escalade')
             );
         }
     }
@@ -191,6 +202,26 @@ class PluginEscaladeNotification
                         }
                         break;
                 }
+            }
+        } else if ($target instanceof NotificationTargetCommonITILObject) {
+            $item = $target->obj;
+
+            switch ($target->data['items_id']) {
+                    // Only last escalation group
+                    case self::NTRGT_TICKET_LAST_ESCALADE_GROUP: // phpcs:ignore
+                        $manager = 0;
+                    case self::NTRGT_TICKET_LAST_ESCALADE_GROUP_MANAGER:
+                        if (!isset($manager)) {
+                            $manager = 1;
+                        }
+                        $history = new PluginEscaladeHistory();
+                        // Retrieve only the last escalation history
+                        foreach ($history->find(['tickets_id' => $item->getID()], ['id DESC'], 1) as $found_history) {
+                            // We only process the first entry (the most recent)
+                            $target->addForGroup($manager, $found_history['groups_id']);
+                            break;
+                        }
+                        break;
             }
         }
     }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -531,9 +531,10 @@ class PluginEscaladeTicket
      * assign a previous group to the ticket
      * @param  int $tickets_id the ticket to change
      * @param  int $groups_id  the group to assign
+     * @param  bool $no_redirect if true, no redirection after the action
      * @return void
      */
-    public static function climb_group($tickets_id, $groups_id)
+    public static function climb_group($tickets_id, $groups_id, $no_redirect = false)
     {
         //don't add group if already exist for this ticket
         $group = new Group();
@@ -579,7 +580,9 @@ class PluginEscaladeTicket
             }
         }
 
-        Html::back();
+        if (!$no_redirect) {
+            Html::back();
+        }
     }
 
 

--- a/setup.php
+++ b/setup.php
@@ -164,6 +164,11 @@ function plugin_init_escalade()
         $PLUGIN_HOOKS['item_action_targets']['escalade']['NotificationTargetPlanningRecall']
          = ['PluginEscaladeNotification', 'getActionTargets'];
 
+        $PLUGIN_HOOKS['item_add_targets']['escalade']['NotificationTargetTicket']
+         = ['PluginEscaladeNotification', 'addTargets'];
+        $PLUGIN_HOOKS['item_action_targets']['escalade']['NotificationTargetTicket']
+         = ['PluginEscaladeNotification', 'getActionTargets'];
+
        // Add additional events for Ticket notifications
         $PLUGIN_HOOKS['item_get_events']['escalade'] = [
             'NotificationTargetTicket' =>  ['PluginEscaladeNotification', 'getEvents']

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -860,10 +860,10 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'assign' => [
                     [
                         'items_id' => $group1['id'],
-                        'itemtype' => 'Group'
-                    ]
+                        'itemtype' => 'Group',
+                    ],
                 ],
-            ]
+            ],
         ]);
         $this->assertGreaterThan(0, $ticket_id);
 
@@ -877,10 +877,10 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'assign' => [
                     [
                         'items_id' => $group2['id'],
-                        'itemtype' => 'Group'
+                        'itemtype' => 'Group',
                     ],
                 ],
-            ]
+            ],
         ]));
 
         // Check notifications
@@ -954,8 +954,8 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->setNotificationTargets(
             $notification->fields['id'],
             [
-                PluginEscaladeNotification::NTRGT_TICKET_LAST_ESCALADE_GROUP
-            ]
+                PluginEscaladeNotification::NTRGT_TICKET_LAST_ESCALADE_GROUP,
+            ],
         );
 
         // Create two groups with users
@@ -971,10 +971,10 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'assign' => [
                     [
                         'items_id' => $group1['id'],
-                        'itemtype' => 'Group'
-                    ]
+                        'itemtype' => 'Group',
+                    ],
                 ],
-            ]
+            ],
         ]);
         $this->assertGreaterThan(0, $ticket_id);
 
@@ -1033,8 +1033,8 @@ final class GroupEscalationTest extends EscaladeTestCase
         $group_id = $this->createItem(
             \Group::class,
             [
-                'name' => $name
-            ]
+                'name' => $name,
+            ],
         )->getID();
 
         $users = [];
@@ -1045,7 +1045,7 @@ final class GroupEscalationTest extends EscaladeTestCase
                 \User::class,
                 [
                     'name' => "{$name}_user_{$i}",
-                ]
+                ],
             )->getID();
 
             $this->createItem(
@@ -1053,7 +1053,7 @@ final class GroupEscalationTest extends EscaladeTestCase
                 [
                     'users_id' => $user_id,
                     'email' => "{$name}_user_{$i}@example.com",
-                ]
+                ],
             );
 
             // Add the user to the group
@@ -1061,21 +1061,21 @@ final class GroupEscalationTest extends EscaladeTestCase
                 \Group_User::class,
                 [
                     'users_id' => $user_id,
-                    'groups_id' => $group_id
-                ]
+                    'groups_id' => $group_id,
+                ],
             )->getID();
 
             $users[] = [
                 'id' => $user_id,
                 'name' => "{$name}_user_{$i}",
-                'email' => "{$name}_user_{$i}@example.com"
+                'email' => "{$name}_user_{$i}@example.com",
             ];
         }
 
         return [
             'id' => $group_id,
             'name' => $name,
-            'users' => $users
+            'users' => $users,
         ];
     }
 
@@ -1109,7 +1109,7 @@ final class GroupEscalationTest extends EscaladeTestCase
             $notification_target->add([
                 'notifications_id' => $notification_id,
                 'type' => 1, // Type 1 = To
-                'items_id' => $target
+                'items_id' => $target,
             ]);
         }
 

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -982,14 +982,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         $this->cleanQueuedNotifications();
 
         // Escalate the ticket to the second group
-        $this->assertTrue($ticket->update([
-            'id' => $ticket_id,
-            '_skip_default_actor' => true,
-            '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($ticket_id, $group2['id']),
-            '_plugin_escalade_no_history' => true,
-            'actortype' => CommonITILActor::ASSIGN,
-            'groups_id' => $group2['id'],
-        ]));
+        \PluginEscaladeTicket::climb_group($ticket_id, $group2['id'], true);
 
         // Check notifications
         $queued = new QueuedNotification();

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -33,7 +33,12 @@ namespace GlpiPlugin\Escalade\Tests\Units;
 use CommonITILActor;
 use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
 use Group_User;
+use NotificationEvent;
+use NotificationTarget;
 use PluginEscaladeConfig;
+use PluginEscaladeNotification;
+use PluginEscaladeTicket;
+use QueuedNotification;
 
 final class GroupEscalationTest extends EscaladeTestCase
 {
@@ -810,5 +815,311 @@ final class GroupEscalationTest extends EscaladeTestCase
         $history = new \PluginEscaladeHistory();
         $this->assertEquals(2, count($history->find(['tickets_id' => $t_id])));
         $this->assertEquals(1, count($history->find(['tickets_id' => $t_id, 'groups_id' => $group1_id])));
+    }
+
+    /**
+     * Test that the standard target "Group in charge of the ticket"
+     * sends notifications to users of both groups (old and new) during an escalation
+     */
+    public function testStandardGroupNotification()
+    {
+        global $CFG_GLPI;
+
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        // Update escalade config
+        $this->assertTrue($config->update([
+            'show_history' => 1,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        // Enable notifications for the test
+        $CFG_GLPI['use_notifications'] = 1;
+        $CFG_GLPI['notifications_mailing'] = 1;
+
+        // Create two groups with users
+        $group1 = $this->createGroupWithUsers('test_standard_group_1', 2);
+        $group2 = $this->createGroupWithUsers('test_standard_group_2', 2);
+
+        // Clear the notification queue
+        $this->cleanQueuedNotifications();
+
+        // Create a ticket assigned to the first group
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name' => 'Test notification standard',
+            'content' => 'Contenu de test',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group1['id'],
+                        'itemtype' => 'Group'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $ticket_id);
+
+        // Clear the notification queue again
+        $this->cleanQueuedNotifications();
+
+        // Escalate the ticket to the second group
+        $this->assertTrue($ticket->update([
+            'id' => $ticket_id,
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group2['id'],
+                        'itemtype' => 'Group'
+                    ],
+                ],
+            ]
+        ]));
+
+        // Check notifications
+        $queued = new QueuedNotification();
+        $notifications = $queued->find();
+
+        // Get the list of notification recipients (emails)
+        $notification_recipients = [];
+        foreach ($notifications as $notif) {
+            $notification_recipients[] = $notif['recipient'];
+        }
+
+        // Check that users from both groups received notifications
+        $group1_user_emails = array_column($group1['users'], 'email');
+        $group2_user_emails = array_column($group2['users'], 'email');
+
+        // At least one user from each group should have received a notification
+        $group1_notified = false;
+        $group2_notified = false;
+
+        foreach ($group1_user_emails as $email) {
+            if (in_array($email, $notification_recipients)) {
+                $group1_notified = true;
+                break;
+            }
+        }
+
+        foreach ($group2_user_emails as $email) {
+            if (in_array($email, $notification_recipients)) {
+                $group2_notified = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($group1_notified, "No user from the original group received a notification");
+        $this->assertTrue($group2_notified, "No user from the new group received a notification");
+    }
+
+    /**
+     * Test that the "Last group escalated in the ticket" target
+     * only sends notifications to users of the last escalated group
+     */
+    public function testLastEscalatedGroupNotification()
+    {
+        global $CFG_GLPI;
+
+        $this->login();
+
+        $config = new PluginEscaladeConfig();
+        $conf = $config->find();
+        $conf = reset($conf);
+        $config->getFromDB($conf['id']);
+        $this->assertGreaterThan(0, $conf['id']);
+
+        // Update escalade config
+        $this->assertTrue($config->update([
+            'show_history' => 1,
+        ] + $conf));
+
+        PluginEscaladeConfig::loadInSession();
+
+        // Enable notifications for the test
+        $CFG_GLPI['use_notifications'] = 1;
+        $CFG_GLPI['notifications_mailing'] = 1;
+
+        // Modify the notification to use the escalation target
+        $notification = new \Notification();
+        $notification->getFromDBByCrit(['itemtype' => 'Ticket', 'event' => 'assign_group']);
+
+        // Add our new target
+        $this->setNotificationTargets(
+            $notification->fields['id'],
+            [
+                PluginEscaladeNotification::NTRGT_TICKET_LAST_ESCALADE_GROUP
+            ]
+        );
+
+        // Create two groups with users
+        $group1 = $this->createGroupWithUsers('test_escalated_group_1', 2);
+        $group2 = $this->createGroupWithUsers('test_escalated_group_2', 2);
+
+        // Create a ticket assigned to the first group
+        $ticket = new \Ticket();
+        $ticket_id = $ticket->add([
+            'name' => 'Test notification escalade',
+            'content' => 'Contenu de test',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group1['id'],
+                        'itemtype' => 'Group'
+                    ]
+                ],
+            ]
+        ]);
+        $this->assertGreaterThan(0, $ticket_id);
+
+        // Clear the notification queue again
+        $this->cleanQueuedNotifications();
+
+        // Escalate the ticket to the second group
+        $this->assertTrue($ticket->update([
+            'id' => $ticket_id,
+            '_skip_default_actor' => true,
+            '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($ticket_id, $group2['id']),
+            '_plugin_escalade_no_history' => true,
+            'actortype' => CommonITILActor::ASSIGN,
+            'groups_id' => $group2['id'],
+        ]));
+
+        // Check notifications
+        $queued = new QueuedNotification();
+        $notifications = $queued->find();
+
+        // Get the list of notification recipients (emails)
+        $notification_recipients = [];
+        foreach ($notifications as $notif) {
+            $notification_recipients[] = $notif['recipient'];
+        }
+
+        // Check that only users from the last group received notifications
+        $group1_user_emails = array_column($group1['users'], 'email');
+        $group2_user_emails = array_column($group2['users'], 'email');
+
+        // Check if users from group 1 received a notification
+        $group1_notified = false;
+        foreach ($group1_user_emails as $email) {
+            if (in_array($email, $notification_recipients)) {
+                $group1_notified = true;
+                break;
+            }
+        }
+
+        // Check if users from group 2 received a notification
+        $group2_notified = false;
+        foreach ($group2_user_emails as $email) {
+            if (in_array($email, $notification_recipients)) {
+                $group2_notified = true;
+                break;
+            }
+        }
+
+        $this->assertFalse($group1_notified, "Users from the original group should not receive a notification");
+        $this->assertTrue($group2_notified, "Users from the new group should receive a notification");
+    }
+
+    /**
+     * Creates a group with users for testing
+     *
+     * @param string $name Group name
+     * @param int $num_users Number of users to create
+     * @return array Group details with its users
+     */
+    private function createGroupWithUsers($name, $num_users = 2)
+    {
+        // Create the group
+        $group_id = $this->createItem(
+            \Group::class,
+            [
+                'name' => $name
+            ]
+        )->getID();
+
+        $users = [];
+
+        // Create users and add them to the group
+        for ($i = 0; $i < $num_users; $i++) {
+            $user_id = $this->createItem(
+                \User::class,
+                [
+                    'name' => "{$name}_user_{$i}",
+                ]
+            )->getID();
+
+            $this->createItem(
+                \UserEmail::class,
+                [
+                    'users_id' => $user_id,
+                    'email' => "{$name}_user_{$i}@example.com",
+                ]
+            );
+
+            // Add the user to the group
+            $group_user_id = $this->createItem(
+                \Group_User::class,
+                [
+                    'users_id' => $user_id,
+                    'groups_id' => $group_id
+                ]
+            )->getID();
+
+            $users[] = [
+                'id' => $user_id,
+                'name' => "{$name}_user_{$i}",
+                'email' => "{$name}_user_{$i}@example.com"
+            ];
+        }
+
+        return [
+            'id' => $group_id,
+            'name' => $name,
+            'users' => $users
+        ];
+    }
+
+    /**
+     * Cleans the notification queue
+     */
+    private function cleanQueuedNotifications()
+    {
+        global $DB;
+        $DB->doQuery("TRUNCATE TABLE `glpi_queuednotifications`");
+
+        $queued = new QueuedNotification();
+        $notifications = $queued->find();
+        $this->assertEmpty($notifications, "The notification queue is not empty after cleaning");
+    }
+
+    /**
+     * Adds notification targets
+     */
+    private function setNotificationTargets($notification_id, array $targets)
+    {
+        //Clear targets
+        $notification_target = new \NotificationTarget();
+        foreach ($notification_target->find(['notifications_id' => $notification_id]) as $target) {
+            $notification_target->delete(['id' => $target['id']]);
+        }
+
+        //Set new targets
+        $notification_target = new \NotificationTarget();
+        foreach ($targets as $target) {
+            $notification_target->add([
+                'notifications_id' => $notification_id,
+                'type' => 1, // Type 1 = To
+                'items_id' => $target
+            ]);
+        }
+
+        $this->assertEquals(count($targets), count($notification_target->find(['notifications_id' => $notification_id])), "The number of notification targets doesn't match after addition");
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !37919 & !38152
- Here is a brief description of what this PR does

### Problem
When escalating a ticket to a new group, multiple notifications were being sent to all previously assigned groups instead of just notifying the newly assigned group.

### Solution
Created two new notification target types:

- "Last group escalated in the ticket"
- "Manager of last group escalated in the ticket"

These targets specifically notify only the most recently added group during ticket escalation, preventing duplicate notifications to previously assigned groups.