### PR TITLE
2.9.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASE]
 
+## [2.9.15] - 2025-07-08
+
 - Fix duplicate notifications being sent during escalation by implementing two additional targets.
 - Fix 8 warnings in the `php-errors.log` file
 - Fix ticket task not added to timeline during escalation

--- a/escalade.xml
+++ b/escalade.xml
@@ -67,6 +67,11 @@ Elle ajoute les fonctionnalités suivantes :
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.10.0-beta1/glpi-escalade-2.10.0-beta1.tar.bz2</download_url>
       </version>
       <version>
+         <num>2.9.15</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.15/glpi-escalade-2.9.15.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.14</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.14/glpi-escalade-2.9.14.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.14');
+define('PLUGIN_ESCALADE_VERSION', '2.9.15');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.15] - 2025-07-08

- Fix duplicate notifications being sent during escalation by implementing two additional targets.
- Fix 8 warnings in the `php-errors.log` file
- Fix ticket task not added to timeline during escalation