### PR TITLE
fix(SLA): SLA escalation actions incorrectly removing users

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -710,7 +710,6 @@ class PluginEscaladeTicket
         $ticket->getFromDB($tickets_id);
         $groups_id = [];
 
-
         // == Add user groups on modification ==
         //check this plugin config
         if (
@@ -718,6 +717,7 @@ class PluginEscaladeTicket
             || $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_modification'] == 0
             || $type != CommonITILActor::ASSIGN
         ) {
+            self::removeAssignUsers($ticket, [$users_id], $type);
             return true;
         }
 


### PR DESCRIPTION
- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38501
- If a user is assigned to a ticket via the action of an SLA, the escalation plugin does not remove old users who were assigned.

## Screenshots (if appropriate):
<img width="1645" height="706" alt="image" src="https://github.com/user-attachments/assets/5478e5d7-6f5a-4d3c-aa3f-8999a9337909" />

