### PR TITLE
Change ticket cloned relation to Duplicated or Link_to

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -935,11 +935,16 @@ class PluginEscaladeTicket
 
         //add link between them
         $ticket_ticket = new Ticket_Ticket();
+        if ($_SESSION['glpi_plugins']['escalade']['config']['cloneandlink_ticket']) {
+            $link_type = Ticket_Ticket::DUPLICATE_WITH;
+        } else {
+            $link_type = Ticket_Ticket::LINK_TO;
+        }
         if (
             !$ticket_ticket->add([
                 'tickets_id_1' => $tickets_id,
                 'tickets_id_2' => $newID,
-                'link'         => Ticket_Ticket::LINK_TO,
+                'link'         => $link_type,
             ])
         ) {
             Session::addMessageAfterRedirect(__('Error : adding link between the two tickets', 'escalade'), false, ERROR);


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39281
- Here is a brief description of what this PR does
If the option to close linked tickets is enabled, when cloning a ticket, the relationship becomes DUPLICATED_WITH instead of LINK_TO.

## Screenshots (if appropriate):
