### PR TITLE
fix(escalade): tech assignment should not trigger escalation behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix the relationship when cloning a ticket: if the `Close linked tickets at the same time` option is enabled, the relationship is `DUPLICATED_WITH` otherwise it's `LINK_TO`
-- Fix tech assignment should not trigger escalation behavior
+- Fix tech assignment should not trigger escalation behavior (as defined in the documentation)
 
 ## [2.9.17] - 2025-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix the relationship when cloning a ticket: if the `Close linked tickets at the same time` option is enabled, the relationship is `DUPLICATED_WITH` otherwise it's `LINK_TO`
+- Fix tech assignment should not trigger escalation behavior
 
 ## [2.9.17] - 2025-08-27
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -142,13 +142,6 @@ class PluginEscaladeTicket
                         }
                     }
                 }
-                if (count($old_users) < count($new_users)) {
-                    $old_ids = array_column($old_users, 'items_id');
-                    $keep_users = array_filter($new_users, function ($user) use ($old_ids) {
-                        return !in_array($user['items_id'], $old_ids);
-                    });
-                    self::removeAssignUsers($item, array_column($keep_users, 'items_id'));
-                }
             }
 
             return $item;

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -712,8 +712,8 @@ final class GroupEscalationTest extends EscaladeTestCase
                 ],
             );
 
-            $this->assertEquals($provider['update_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])), 'Failed with config: '.json_encode($provider['conf']));
-            $this->assertEquals($provider['update_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])), 'Failed with config: '.json_encode($provider['conf']));
+            $this->assertEquals($provider['update_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])), 'Failed with config: ' . json_encode($provider['conf']));
+            $this->assertEquals($provider['update_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])), 'Failed with config: ' . json_encode($provider['conf']));
 
             if ($provider['conf']['use_assign_user_group_modification'] === 1) {
                 if ($provider['conf']['use_assign_user_group'] === 1) {

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -205,7 +205,7 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'group_ticket' => 0,
             ],
             'update_expected' => [
-                'user_ticket' => 1,
+                'user_ticket' => 2,
                 'group_ticket' => 0,
             ],
         ];
@@ -259,7 +259,7 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'group_ticket' => 1,
             ],
             'update_expected' => [
-                'user_ticket' => 1,
+                'user_ticket' => 2,
                 'group_ticket' => 1,
             ],
         ];
@@ -439,7 +439,7 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'group_ticket' => 1,
             ],
             'update_expected' => [
-                'user_ticket' => 1,
+                'user_ticket' => 2,
                 'group_ticket' => 1,
             ],
         ];
@@ -712,8 +712,8 @@ final class GroupEscalationTest extends EscaladeTestCase
                 ],
             );
 
-            $this->assertEquals($provider['update_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])));
-            $this->assertEquals($provider['update_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])));
+            $this->assertEquals($provider['update_expected']['user_ticket'], count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])), 'Failed with config: '.json_encode($provider['conf']));
+            $this->assertEquals($provider['update_expected']['group_ticket'], count($group_ticket->find(['tickets_id' => $ticket->getID(), 'type' => CommonITILActor::ASSIGN])), 'Failed with config: '.json_encode($provider['conf']));
 
             if ($provider['conf']['use_assign_user_group_modification'] === 1) {
                 if ($provider['conf']['use_assign_user_group'] === 1) {

--- a/tests/Units/UserEscalationTest.php
+++ b/tests/Units/UserEscalationTest.php
@@ -233,9 +233,9 @@ final class UserEscalationTest extends EscaladeTestCase
             ],
         );
 
-        // Check if user is disassociated to this ticket and the group replace it
+        // Check if user is associated to this ticket and have dont been removed the other user
         $ticket_user = new \Ticket_User();
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
         // Disable remove tech options
         $this->updateItem(
@@ -287,7 +287,7 @@ final class UserEscalationTest extends EscaladeTestCase
             ],
         );
 
-        // Check if the user and group are associated to this ticket
+        // Check if the user are associated to this ticket
         $ticket_user = new \Ticket_User();
         $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
     }
@@ -360,7 +360,7 @@ final class UserEscalationTest extends EscaladeTestCase
         // Check if user is disassociated to this ticket and the group replace it
         $ticket_user = new \Ticket_User();
         $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN, 'users_id' => $user2->getID()])));
-        $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
+        $this->assertEquals(2, count($ticket_user->find(['tickets_id' => $ticket->getID(), 'type' => \CommonITILActor::ASSIGN])));
 
         // Disable remove tech options
         $this->updateItem(


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #368
- The plugin documentation specifies that only groups can escalate a ticket. This pull request therefore removes the ability for technicians to perform this action.

## Screenshots (if appropriate):

<img width="306" height="84" alt="image" src="https://github.com/user-attachments/assets/cc191f8a-f699-4548-9bb6-d0501108ca08" />

