### PR TITLE
2.9.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [2.9.18] - 2025-30-09
+
 ### Fixed
 
 - Fix template mandatory field validation interference when adding solutions to tickets
@@ -15,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.9.17] - 2025-08-27
 
-### Fixed 
+### Fixed
 
 - Rename options related to ticket cloning and closure to avoid ambiguity
 - Fix rule doesn't trigger when user uses "Assign myself" button

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.9.18</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.18/glpi-escalade-2.9.18.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.17</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.17/glpi-escalade-2.9.17.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.17');
+define('PLUGIN_ESCALADE_VERSION', '2.9.18');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.18] - 2025-30-09

### Fixed

- Fix template mandatory field validation interference when adding solutions to tickets
- Fix the relationship when cloning a ticket: if the `Close linked tickets at the same time` option is enabled, the relationship is `DUPLICATED_WITH` otherwise it's `LINK_TO`
- Fix tech assignment should not trigger escalation behavior (as defined in the documentation)