### PR TITLE
Fix tag deletion before escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## Fixed
+
+- Fix `tag` deletion before escalation using `Escalate button`
+
 ## [2.9.18] - 2025-30-09
 
 ### Fixed

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -39,6 +39,30 @@ class PluginEscaladeTicket
 {
     public const MANAGED_BY_CORE = -1; // Status managed by core, not by plugin
 
+    /**
+     * Preserve existing tags when updating a ticket
+     * This prevents tags from being removed during escalation operations
+     *
+     * @param int $tickets_id The ticket ID
+     * @param array $update_data The update data array (passed by reference)
+     * @return void
+     */
+    private static function preserveExistingTags(int $tickets_id, array &$update_data): void
+    {
+        // Preserve existing tags if Tag plugin is active
+        if (Plugin::isPluginActive('tag') && class_exists('PluginTagTagItem')) {
+            $tag_item = new PluginTagTagItem();
+            $existing_tags = $tag_item->find([
+                'items_id' => $tickets_id,
+                'itemtype' => 'Ticket'
+            ]);
+            if (!empty($existing_tags)) {
+                $tag_ids = array_column($existing_tags, 'plugin_tag_tags_id');
+                $update_data['_plugin_tag_tag_values'] = $tag_ids;
+            }
+        }
+    }
+
     public static function pre_item_update(CommonDBTM $item)
     {
         // Only process escalation logic if we're dealing with actor assignments
@@ -615,14 +639,20 @@ class PluginEscaladeTicket
                     '<p><i>' . sprintf(__('Escalation to the group %s.', 'escalade'), Sanitizer::unsanitize($group->getName())) . '</i></p><hr />',
                 ),
             ]);
-            $ticket = new Ticket();
-            $ticket->update([
+            
+            $update_data = [
                 'id'           => $tickets_id,
                 '_itil_assign' => [
                     'groups_id' => $groups_id,
                     '_type'    => 'group',
                 ],
-            ]);
+            ];
+            
+            // Preserve existing tags
+            self::preserveExistingTags($tickets_id, $update_data);
+            
+            $ticket = new Ticket();
+            $ticket->update($update_data);
         }
 
         if (!$no_redirect) {
@@ -1081,14 +1111,19 @@ class PluginEscaladeTicket
         ]);
 
         if (empty($found)) {
-            $ticket = new Ticket();
-            $ticket->update([
+            $update_data = [
                 'id'           => $tickets_id,
                 '_itil_assign' => [
                     'users_id' => $_SESSION['glpiID'],
                     '_type'    => 'user',
                 ],
-            ]);
+            ];
+            
+            // Preserve existing tags
+            self::preserveExistingTags($tickets_id, $update_data);
+            
+            $ticket = new Ticket();
+            $ticket->update($update_data);
         }
     }
 
@@ -1306,16 +1341,20 @@ class PluginEscaladeTicket
             if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != -1) {
                 $_form_object['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
             }
+            
+            $update_data = $options['ticket_details'] + [
+                '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
+                '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+                'actortype' => CommonITILActor::ASSIGN,
+                'groups_id' => $group_id,
+                '_form_object' => $_form_object,
+            ];
+            
+            // Preserve existing tags
+            self::preserveExistingTags($tickets_id, $update_data);
+            
             $updates_ticket = new Ticket();
-            $updates_ticket->update(
-                $options['ticket_details'] + [
-                    '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
-                    '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
-                    'actortype' => CommonITILActor::ASSIGN,
-                    'groups_id' => $group_id,
-                    '_form_object' => $_form_object,
-                ],
-            );
+            $updates_ticket->update($update_data);
         }
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39553
- Here is a brief description of what this PR does
When escalating via the Escalate button in the plugin, the tags associated with the ticket by the Tag plugin are deleted.

## Screenshots (if appropriate):
