### PR TITLE
Refactor (Tests) - Use DbTestCase instead of TestCase

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -616,10 +616,14 @@ class PluginEscaladeTicket
             ]);
             $ticket = new Ticket();
             $ticket->update([
-                'id'           => $tickets_id,
-                '_itil_assign' => [
-                    'groups_id' => $groups_id,
-                    '_type'    => 'group',
+                'id'      => $tickets_id,
+                '_actors' => [
+                    'assign' => [
+                        [
+                            'items_id' => $groups_id,
+                            'itemtype' => 'Group',
+                        ],
+                    ],
                 ],
             ]);
         }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <phpunit bootstrap="tests/bootstrap.php" colors="true" testdox="true">
    <testsuites>
-      <testsuite name="Tests">
-         <directory>tests</directory>
+      <testsuite name="Units">
+         <directory>tests/Units</directory>
       </testsuite>
    </testsuites>
 </phpunit>

--- a/tests/Units/TicketTest.php
+++ b/tests/Units/TicketTest.php
@@ -32,202 +32,71 @@ namespace GlpiPlugin\Escalade\Tests\Units;
 
 use CommonITILActor;
 use CommonITILObject;
-use CommonITILValidation;
 use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
 use ITILCategory;
 use ITILSolution;
 use PluginEscaladeConfig;
 use PluginEscaladeTicket;
+use Ticket;
 
 final class TicketTest extends EscaladeTestCase
 {
-    public function testCloseClonedTicket()
-    {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-
-        // Test 1: Test with cloneandlink_ticket = 1 and close_linkedtickets = 1
-        $this->assertTrue($config->update([
-            'cloneandlink_ticket' => 1,
-            'close_linkedtickets' => 1,
-        ] + $conf));
-
-        PluginEscaladeConfig::loadInSession();
-
-        // Create the first ticket
-        $ticket = new \Ticket();
-        $this->assertEquals(0, count($ticket->find(['name' => 'Escalade Clone and Link Test 1'])));
-
-        $t_id = $ticket->add([
-            'name' => 'Escalade Clone and Link Test 1',
-            'content' => 'Content of test ticket 1',
-        ]);
-        $this->assertGreaterThan(0, $t_id);
-
-        // Execute cloneAndLink on this ticket
-        PluginEscaladeTicket::cloneAndLink($t_id);
-
-        // Verify that the ticket has been cloned
-        $this->assertEquals(2, count($ticket->find(['name' => 'Escalade Clone and Link Test 1'])));
-
-        // Verify that the link is of type DUPLICATE_WITH
-        $ticket_ticket = new \Ticket_Ticket();
-        $links = $ticket_ticket->find([
-            'tickets_id_1' => $t_id,
-        ]);
-        $this->assertCount(1, $links);
-        $link = reset($links);
-        $this->assertEquals(\Ticket_Ticket::DUPLICATE_WITH, $link['link']);
-
-        // Get the cloned ticket
-        $cloned_ticket = new \Ticket();
-        $ct = $cloned_ticket->getFromDBByCrit([
-            'name' => 'Escalade Clone and Link Test 1',
-            'NOT' => ['id' => $t_id],
-        ]);
-        $this->assertTrue($ct);
-        $cloned_id = $cloned_ticket->fields['id'];
-
-        // Change the parent ticket status to SOLVED
-        $parent_ticket = new \Ticket();
-        $parent_ticket->getFromDB($t_id);
-        $parent_ticket->update([
-            'id' => $t_id,
-            'status' => CommonITILObject::SOLVED,
-        ]);
-
-        // Verify that the cloned ticket is also solved (automatically by GLPI core)
-        $cloned_ticket->getFromDB($cloned_id);
-        $this->assertEquals(CommonITILObject::SOLVED, $cloned_ticket->fields['status']);
-
-        // Test2: Test with cloneandlink_ticket = 1 and close_linkedtickets = 0
-        $this->assertTrue($config->update([
-            'cloneandlink_ticket' => 1,
-            'close_linkedtickets' => 0,
-        ] + $conf));
-
-        PluginEscaladeConfig::loadInSession();
-
-        // Create the second ticket
-        $ticket = new \Ticket();
-        $this->assertEquals(0, count($ticket->find(['name' => 'Escalade Clone and Link Test 2'])));
-        $t_id = $ticket->add([
-            'name' => 'Escalade Clone and Link Test 2',
-            'content' => 'Content of test ticket 2',
-        ]);
-        $this->assertGreaterThan(0, $t_id);
-
-        // Execute cloneAndLink on this ticket
-        PluginEscaladeTicket::cloneAndLink($t_id);
-
-        // Verify that the ticket has been cloned
-        $this->assertEquals(2, count($ticket->find(['name' => 'Escalade Clone and Link Test 2'])));
-
-        // Verify that the link is of type LINK_TO
-        $ticket_ticket = new \Ticket_Ticket();
-        $links = $ticket_ticket->find([
-            'tickets_id_1' => $t_id,
-        ]);
-        $this->assertCount(1, $links);
-        $link = reset($links);
-        $this->assertEquals(\Ticket_Ticket::LINK_TO, $link['link']);
-
-        // Get the cloned ticket
-        $cloned_ticket = new \Ticket();
-        $ct = $cloned_ticket->getFromDBByCrit([
-            'name' => 'Escalade Clone and Link Test 2',
-            'NOT' => ['id' => $t_id],
-        ]);
-        $this->assertTrue($ct);
-        $cloned_id = $cloned_ticket->fields['id'];
-
-        // Change the parent ticket status to SOLVED
-        $parent_ticket = new \Ticket();
-        $parent_ticket->getFromDB($t_id);
-        $parent_ticket->update([
-            'id' => $t_id,
-            'status' => CommonITILObject::SOLVED,
-        ]);
-
-        // Verify that the cloned ticket is not solved
-        $cloned_ticket->getFromDB($cloned_id);
-        $this->assertNotEquals(CommonITILObject::SOLVED, $cloned_ticket->fields['status']);
-    }
-
     public function testEscalationWithMandatoryFields()
     {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-
-        PluginEscaladeConfig::loadInSession();
+        $this->initConfig();
 
         // Create ticket template without mandatory fields
-        $template = new \TicketTemplate();
-        $template_id = $template->add([
+        $template = $this->createItem('TicketTemplate', [
             'name' => 'Test template for escalation',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $template_id);
+        $template_id = $template->getID();
 
         // Create a category linked to this template
-        $category = new \ITILCategory();
-        $category_id = $category->add([
+        $category = $this->createItem('ITILCategory', [
             'name' => 'Test category with template',
             'tickettemplates_id_incident' => $template_id,
             'is_incident' => 1,
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $category_id);
+        $category_id = $category->getID();
 
         // Create first group for assignment
-        $group1 = new \Group();
-        $group1_id = $group1->add([
+        $group1 = $this->createItem('Group', [
             'name' => 'Group for escalation test 1',
             'entities_id' => 0,
             'is_recursive' => 1,
             'is_assign' => 1,
         ]);
-        $this->assertGreaterThan(0, $group1_id);
+        $group1_id = $group1->getID();
 
         // Create second group for escalation
-        $group2 = new \Group();
-        $group2_id = $group2->add([
+        $group2 = $this->createItem('Group', [
             'name' => 'Group for escalation test 2',
             'entities_id' => 0,
             'is_recursive' => 1,
             'is_assign' => 1,
         ]);
-        $this->assertGreaterThan(0, $group2_id);
+        $group2_id = $group2->getID();
 
         // Create a ticket with the template and first group assigned
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem('Ticket', [
             'name' => 'Test ticket for escalation',
             'content' => 'Content for test ticket',
+            'entities_id' => 0,
             'itilcategories_id' => $category_id,
             '_groups_id_assign' => [$group1_id],
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket_id = $ticket->getID();
 
         // Add a mandatory field to the template
-        $mandatory_field = new \TicketTemplateMandatoryField();
-        $mandatory_field_id = $mandatory_field->add([
+        $mandatory_field = $this->createItem('TicketTemplateMandatoryField', [
             'tickettemplates_id' => $template_id,
             'num' => 10, // impact field
         ]);
-        $this->assertGreaterThan(0, $mandatory_field_id);
+        $mandatory_field_id = $mandatory_field->getID();
 
         // Now try to escalate the ticket without filling the mandatory field
         // First, create a properly configured ticket instance
@@ -260,11 +129,9 @@ final class TicketTest extends EscaladeTestCase
 
         // Now simulate a case where all mandatory fields are filled
         // Update the ticket with the mandatory field
-        $update_success = $ticket->update([
-            'id' => $ticket_id,
+        $this->updateItem('Ticket', $ticket_id, [
             'impact' => 3, // Fill the mandatory field
         ]);
-        $this->assertTrue($update_success);
 
         // Refresh the ticket data
         $ticket_instance->getFromDB($ticket_id);
@@ -307,15 +174,15 @@ final class TicketTest extends EscaladeTestCase
         );
 
         // Add the group to actually test the escalation
-        $group_ticket = new \Group_Ticket();
-        $group_ticket->add([
+        $group_ticket = $this->createItem('Group_Ticket', [
             'tickets_id' => $ticket_id,
             'groups_id' => $group2_id,
             'type' => CommonITILActor::ASSIGN,
         ]);
 
         // Verify that the group was added
-        $assigned_groups = $group_ticket->find([
+        $group_ticket_finder = new \Group_Ticket();
+        $assigned_groups = $group_ticket_finder->find([
             'tickets_id' => $ticket_id,
             'type' => CommonITILActor::ASSIGN,
         ]);
@@ -335,32 +202,22 @@ final class TicketTest extends EscaladeTestCase
      */
     public function testTriggerEscalationAndExecuteRuleOnTicket()
     {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-
-        PluginEscaladeConfig::loadInSession();
+        $this->initConfig();
 
         // Create a group
-        $group_observer = new \Group();
-        $group_observer_id = $group_observer->add([
+        $group_observer = $this->createItem('Group', [
             'name' => 'Group Observer',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $group_observer_id);
+        $group_observer_id = $group_observer->getID();
 
-        $group_tech = new \Group();
-        $group_tech_id = $group_tech->add([
+        $group_tech = $this->createItem('Group', [
             'name' => 'Group tech',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $group_tech_id);
+        $group_tech_id = $group_tech->getID();
 
         // Get the tech user
         $user_tech = new \User();
@@ -368,34 +225,31 @@ final class TicketTest extends EscaladeTestCase
         $this->assertGreaterThan(0, $user_tech->getID());
 
         // Create a rule to assign the group observer if the group tech or tech user is assigned
-        $rule = new \Rule();
-        $rule_id = $rule->add([
+        $rule = $this->createItem('Rule', [
             'name' => 'Add RuleTicket',
             'sub_type' => 'RuleTicket',
             'match' => 'OR',
             'is_active' => 1,
             'condition' => 2,
+            'entities_id' => 0,
         ]);
-        $this->assertGreaterThan(0, $rule_id);
+        $rule_id = $rule->getID();
 
-        $rule_action = new \RuleAction();
-        $rule_action->add([
+        $rule_action = $this->createItem('RuleAction', [
             'rules_id' => $rule_id,
             'action_type' => 'assign',
             'field' => '_groups_id_observer',
             'value' => $group_observer_id,
         ]);
 
-        $rule_criteria = new \RuleCriteria();
-        $rule_criteria->add([
+        $rule_criteria = $this->createItem('RuleCriteria', [
             'rules_id' => $rule_id,
             'criteria' => '_groups_id_assign',
             'condition' => 0,
             'pattern' => $group_tech_id,
         ]);
 
-        $rule_criteria2 = new \RuleCriteria();
-        $rule_criteria2->add([
+        $rule_criteria2 = $this->createItem('RuleCriteria', [
             'rules_id' => $rule_id,
             'criteria' => '_users_id_assign',
             'condition' => 0,
@@ -404,13 +258,12 @@ final class TicketTest extends EscaladeTestCase
 
         // Test the rule ticket during the escalation
         foreach ($this->escalateTicketMethods(['escalateWithTimelineButton', 'escalateWithHistoryButton', 'escalateWithAssignMySelfButton']) as $data) {
-            $ticket = new \Ticket();
-            $ticket_id = $ticket->add([
+            $ticket = $this->createItem('Ticket', [
                 'name' => 'Test ticket for escalation',
                 'content' => 'Content for test ticket',
+                'entities_id' => 0,
             ]);
-            $this->assertGreaterThan(0, $ticket_id);
-            $ticket->getFromDB($ticket_id);
+            $ticket_id = $ticket->getID();
 
             $group_ticket = new \Group_Ticket();
             $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group_observer_id, 'type' => \CommonITILActor::OBSERVER])));
@@ -432,60 +285,49 @@ final class TicketTest extends EscaladeTestCase
 
     public function testTicketUpdateDoesNotChangeITILCategoryAssignedGroup()
     {
-        $this->login(TU_USER, TU_PASS);
-
-        $entity = new \Entity();
-        $entity->update([
-            'id' => 0,
-            'auto_assign_mode' => \Entity::AUTO_ASSIGN_CATEGORY_HARDWARE,
-        ]);
-
-        $config = new PluginEscaladeConfig();
-        $config->update([
-            'id' => 1,
+        $this->initConfig([
             'reassign_group_from_cat' => 1,
             'remove_group' => 1,
         ]);
 
-        PluginEscaladeConfig::loadInSession();
+        $this->updateItem('Entity', 0, [
+            'auto_assign_mode' => \Entity::AUTO_ASSIGN_CATEGORY_HARDWARE,
+        ]);
 
-        $group1 = new \Group();
-        $group1_id = $group1->add([
+        $group1 = $this->createItem('Group', [
             'name' => 'Group tech',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $group1_id);
+        $group1_id = $group1->getID();
 
-        $group2 = new \Group();
-        $group2_id = $group2->add([
+        $group2 = $this->createItem('Group', [
             'name' => 'Group tech 2',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $group2_id);
+        $group2_id = $group2->getID();
 
-        $itil_cat = new \ITILCategory();
-        $itil_cat_id = $itil_cat->add([
+        $itil_cat = $this->createItem('ITILCategory', [
             'name' => 'Cat1',
             'groups_id' => $group1_id,
+            'entities_id' => 0,
         ]);
-        $this->assertGreaterThan(0, $itil_cat_id);
+        $itil_cat_id = $itil_cat->getID();
 
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem('Ticket', [
             'name' => 'Test ticket for escalation',
             'content' => 'Content for test ticket',
+            'entities_id' => 0,
             'itilcategories_id' => $itil_cat_id,
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket_id = $ticket->getID();
 
         $group_ticket = new \Group_Ticket();
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id, 'type' => \CommonITILActor::ASSIGN])));
 
-        $ticket->update([
-            'id' => $ticket_id,
+        $this->updateItem('Ticket', $ticket_id, [
             '_actors' => [
                 'assign' => [
                     [
@@ -503,8 +345,7 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id, 'type' => \CommonITILActor::ASSIGN])));
 
-        $ticket->update([
-            'id' => $ticket_id,
+        $this->updateItem('Ticket', $ticket_id, [
             'status' => \CommonITILObject::WAITING,
         ]);
 
@@ -514,19 +355,10 @@ final class TicketTest extends EscaladeTestCase
 
     public function testStatusTicketOption()
     {
-        $this->login();
-
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-        $this->assertTrue($config->update([
+        $this->initConfig([
             'ticket_last_status' => \CommonITILObject::INCOMING,
             'remove_tech' => 0,
-        ] + $conf));
-
-        PluginEscaladeConfig::loadInSession();
+        ]);
 
         $user1 = new \User();
         $user1->getFromDBbyName('tech');
@@ -536,20 +368,19 @@ final class TicketTest extends EscaladeTestCase
         $user2->getFromDBbyName('glpi');
         $this->assertGreaterThan(0, $user2->getID());
 
-        $group_tech = new \Group();
-        $group_tech_id = $group_tech->add([
+        $group_tech = $this->createItem('Group', [
             'name' => 'Group tech',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $group_tech_id);
+        $group_tech_id = $group_tech->getID();
 
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem('Ticket', [
             'name' => 'Test ticket',
             'content' => 'Content',
+            'entities_id' => 0,
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket_id = $ticket->getID();
 
         $ticket->getFromDB($ticket_id);
         $this->assertEquals(\CommonITILObject::INCOMING, $ticket->fields['status']);
@@ -559,9 +390,10 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(0, count($user_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN])));
 
-        $this->assertTrue(
-            $ticket->update([
-                'id' => $ticket_id,
+        $this->updateItem(
+            \Ticket::class,
+            $ticket_id,
+            [
                 '_actors' => [
                     'assign' => [
                         [
@@ -570,7 +402,7 @@ final class TicketTest extends EscaladeTestCase
                         ],
                     ],
                 ],
-            ]),
+            ],
         );
         $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($user_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN])));
@@ -578,9 +410,10 @@ final class TicketTest extends EscaladeTestCase
         $ticket->getFromDB($ticket_id);
         $this->assertEquals(\CommonITILObject::ASSIGNED, $ticket->fields['status']);
 
-        $this->assertTrue(
-            $ticket->update([
-                'id' => $ticket_id,
+        $this->updateItem(
+            \Ticket::class,
+            $ticket_id,
+            [
                 '_actors' => [
                     'assign' => [
                         [
@@ -593,7 +426,7 @@ final class TicketTest extends EscaladeTestCase
                         ],
                     ],
                 ],
-            ]),
+            ],
         );
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN, 'groups_id' => $group_tech_id])));
@@ -602,15 +435,28 @@ final class TicketTest extends EscaladeTestCase
         $ticket->getFromDB($ticket_id);
         $this->assertEquals(\CommonITILObject::INCOMING, $ticket->fields['status']);
 
-        $this->assertTrue(
-            $ticket->update([
-                'id' => $ticket_id,
-                '_itil_assign' => [
-                    '_type' => "user",
-                    'users_id' => $user2->getID(),
-                    'use_notification' => 1,
+        $this->updateItem(
+            \Ticket::class,
+            $ticket_id,
+            [
+                '_actors' => [
+                    'assign' => [
+                        [
+                            'items_id' => $user1->getID(),
+                            'itemtype' => 'User',
+                        ],
+                        [
+                            'items_id' => $group_tech_id,
+                            'itemtype' => 'Group',
+                        ],
+                        [
+                            'items_id' => $user2->getID(),
+                            'itemtype' => 'User',
+                            'use_notification' => 1,
+                        ],
+                    ],
                 ],
-            ]),
+            ],
         );
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'type' => \CommonITILActor::ASSIGN, 'groups_id' => $group_tech_id])));
@@ -866,6 +712,8 @@ final class TicketTest extends EscaladeTestCase
 
     public function testAssignGroupToTicketWithCategory()
     {
+        $this->initConfig();
+
         $ticket_user = new \Ticket_User();
         $ticket_group = new \Group_Ticket();
 
@@ -877,68 +725,81 @@ final class TicketTest extends EscaladeTestCase
         $user2->getFromDBbyName('tech');
         $this->assertGreaterThan(0, $user2->getID());
 
-        $this->login(TU_USER, TU_PASS);
+        $this->updateItem(
+            \Entity::class,
+            $this->getTestRootEntity(true),
+            [
+                'id' => 0,
+                'auto_assign_mode' => 2,
+            ],
+        );
 
-        $entity = new \Entity();
-        $entity->update([
-            'id' => 0,
-            'auto_assign_mode' => 2,
-        ]);
+        [$group1, $group2] = $this->createItems(
+            \Group::class,
+            [
+                [
+                    'name' => 'GLPI Group',
+                    'entities_id' => $this->getTestRootEntity(true),
+                ],
+                [
+                    'name' => 'TECH Group',
+                    'entities_id' => $this->getTestRootEntity(true),
+                ],
+            ],
+        );
 
-        $group1 = new \Group();
-        $group1_id = $group1->add([
-            'name' => 'GLPI Group',
-        ]);
-        $this->assertGreaterThan(0, $group1_id);
+        $group1_id = $group1->getID();
+        $group2_id = $group2->getID();
 
-        $group2 = new \Group();
-        $group2_id = $group2->add([
-            'name' => 'TECH Group',
-        ]);
-        $this->assertGreaterThan(0, $group2_id);
+        $this->createItems(
+            \Group_User::class,
+            [
+                [
+                    'users_id' => $user1->getID(),
+                    'groups_id' => $group1_id,
+                ],
+                [
+                    'users_id' => $user2->getID(),
+                    'groups_id' => $group2_id,
+                ],
+            ],
+        );
 
-        $group_user1 = new \Group_User();
-        $group_user1->add([
-            'users_id' => $user1->getID(),
-            'groups_id' => $group1_id,
-        ]);
+        [$itil_category1, $itil_category2] = $this->createItems(
+            ITILCategory::class,
+            [
+                [
+                    'name' => 'Cat1',
+                    'users_id' => $user1->getID(),
+                    'groups_id' => $group1_id,
+                    'entities_id' => $this->getTestRootEntity(true),
+                ],
+                [
+                    'name' => 'Cat2',
+                    'users_id' => $user2->getID(),
+                    'groups_id' => $group2_id,
+                    'entities_id' => $this->getTestRootEntity(true),
+                ],
+            ],
+        );
 
-        $group_user2 = new \Group_User();
-        $group_user2->add([
-            'users_id' => $user2->getID(),
-            'groups_id' => $group2_id,
-        ]);
-
-        $itil_category1 = new \ITILCategory();
-        $itil_category1_id = $itil_category1->add([
-            'name' => 'Cat1',
-            'users_id' => $user1->getID(),
-            'groups_id' => $group1_id,
-        ]);
-        $this->assertGreaterThan(0, $itil_category1_id);
-
-        $itil_category2 = new \ITILCategory();
-        $itil_category2_id = $itil_category2->add([
-            'name' => 'Cat2',
-            'users_id' => $user2->getID(),
-            'groups_id' => $group2_id,
-        ]);
-        $this->assertGreaterThan(0, $itil_category2_id);
+        $itil_category1_id = $itil_category1->getID();
+        $itil_category2_id = $itil_category2->getID();
 
         foreach ($this->testAssignGroupToTicketWithCategoryProvider() as $provider) {
             // Update escalade config
-            $config = new PluginEscaladeConfig();
-            $config->update(array_merge(['id' => 1], $provider['conf']));
+            $this->initConfig($provider['conf'] + ['use_assign_user_group' => 0]);
 
-            PluginEscaladeConfig::loadInSession();
-
-            $ticket = new \Ticket();
-            $ticket_id = $ticket->add([
-                'name' => 'Assign Cat Escalation Test',
-                'content' => 'content',
-                'itilcategories_id' => $itil_category1_id,
-            ]);
-            $this->assertGreaterThan(0, $ticket_id);
+            $ticket = $this->createItem(
+                Ticket::class,
+                [
+                    'name' => 'Assign Cat Escalation Test',
+                    'content' => 'content',
+                    'itilcategories_id' => $itil_category1_id,
+                    'entities_id' => $this->getTestRootEntity(true),
+                ],
+            );
+            $ticket_id = $ticket->getID();
 
             $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket_id])));
             $this->assertEquals(1, count($ticket_user->find(['tickets_id' => $ticket_id, 'users_id' => $user1->getID()])));
@@ -947,15 +808,19 @@ final class TicketTest extends EscaladeTestCase
             $this->assertEquals(1, count($ticket_group->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id])));
             $this->assertEquals(0, count($ticket_group->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id])));
 
-            $ticket->update([
-                'id' => $ticket_id,
-                'itilcategories_id' => $itil_category2_id,
-            ]);
+            $this->updateItem(
+                Ticket::class,
+                $ticket_id,
+                [
+                    'id' => $ticket_id,
+                    'itilcategories_id' => $itil_category2_id,
+                ],
+            );
 
             $this->assertEquals($provider['expected']['user_1_is_assign'], count($ticket_user->find(['tickets_id' => $ticket_id, 'users_id' => $user1->getID()])));
             $this->assertEquals($provider['expected']['user_2_is_assign'], count($ticket_user->find(['tickets_id' => $ticket_id, 'users_id' => $user2->getID()])));
             $this->assertEquals($provider['expected']['group_1_is_assign'], count($ticket_group->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id])));
-            $this->assertEquals($provider['expected']['group_2_is_assign'], count($ticket_group->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id])));
+            $this->assertEquals($provider['expected']['group_2_is_assign'], count($ticket_group->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id])), "Failed with config: " . print_r($provider['conf'], true) . " and expected: " . print_r($provider['expected'], true));
         }
     }
 
@@ -966,63 +831,51 @@ final class TicketTest extends EscaladeTestCase
      */
     public function testAddSolutionWithMandatoryTemplateFields()
     {
-        $this->login();
-
-        // Load Escalade plugin configuration
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-        PluginEscaladeConfig::loadInSession();
+        $this->initConfig();
 
         // Create a ticket template with mandatory requester field
-        $template = new \TicketTemplate();
-        $template_id = $template->add([
+        $template = $this->createItem('TicketTemplate', [
             'name' => 'Template with mandatory requester',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $template_id);
+        $template_id = $template->getID();
 
         // Add mandatory field (requester) to the template
-        $mandatory_field = new \TicketTemplateMandatoryField();
-        $mandatory_field_id = $mandatory_field->add([
+        $mandatory_field = $this->createItem('TicketTemplateMandatoryField', [
             'tickettemplates_id' => $template_id,
             'num' => 4, // _users_id_requester field number
         ]);
-        $this->assertGreaterThan(0, $mandatory_field_id);
+        $mandatory_field_id = $mandatory_field->getID();
 
         // Create a category linked to this template
-        $category = new \ITILCategory();
-        $category_id = $category->add([
+        $category = $this->createItem('ITILCategory', [
             'name' => 'Category with mandatory template',
             'tickettemplates_id_incident' => $template_id,
             'is_incident' => 1,
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
-        $this->assertGreaterThan(0, $category_id);
+        $category_id = $category->getID();
 
         // Create a user to be the requester
-        $user = new \User();
-        $user_id = $user->add([
+        $user = $this->createItem('User', [
             'name' => 'test_requester',
             'realname' => 'Test Requester',
             'firstname' => 'User',
         ]);
-        $this->assertGreaterThan(0, $user_id);
+        $user_id = $user->getID();
 
         // Create a ticket with the template and mandatory requester filled
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem('Ticket', [
             'name' => 'Ticket for solution test',
             'content' => 'Content for solution test',
             'itilcategories_id' => $category_id,
             '_users_id_requester' => [$user_id],
             'status' => CommonITILObject::ASSIGNED,
+            'entities_id' => 0,
         ]);
-        $this->assertGreaterThan(0, $ticket_id);
+        $ticket_id = $ticket->getID();
 
         // Verify the ticket was created with the requester
         $ticket->getFromDB($ticket_id);
@@ -1039,33 +892,34 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals($user_id, $requester['users_id']);
 
         // Create a solution type
-        $solution_type = new \SolutionType();
-        $solution_type_id = $solution_type->add([
+        $solution_type = $this->createItem('SolutionType', [
             'name' => 'Test solution type',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
+        $solution_type_id = $solution_type->getID();
         $this->assertGreaterThan(0, $solution_type_id);
 
         // Now try to add a solution to the ticket - this should work without validation errors
         // In GLPI, we need to add the solution using ITILSolution, then update the ticket status
-        $solution = new ITILSolution();
-        $solution_id = $solution->add([
+        $solution = $this->createItem('ITILSolution', [
             'itemtype' => 'Ticket',
             'items_id' => $ticket_id,
             'solutiontypes_id' => $solution_type_id,
             'content' => 'This is the solution to the problem.',
         ]);
+        $solution_id = $solution->getID();
         $this->assertGreaterThan(0, $solution_id);
 
         // Update ticket status to solved - this is where the template validation could fail
-        $success = $ticket->update([
-            'id' => $ticket_id,
-            'status' => CommonITILObject::SOLVED,
-        ]);
-
-        // The update should succeed
-        $this->assertTrue($success);
+        $this->updateItem(
+            Ticket::class,
+            $ticket_id,
+            [
+                'id' => $ticket_id,
+                'status' => CommonITILObject::SOLVED,
+            ],
+        );
 
         // Reload the ticket and verify it's now solved
         $ticket->getFromDB($ticket_id);
@@ -1104,62 +958,55 @@ final class TicketTest extends EscaladeTestCase
      */
     public function testAssignMeWithMandatoryTemplateFields()
     {
-        $this->login();
-
-        // Load Escalade plugin configuration
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-        PluginEscaladeConfig::loadInSession();
+        $this->initConfig();
 
         // Create a ticket template with mandatory requester field
-        $template = new \TicketTemplate();
-        $template_id = $template->add([
+        $template = $this->createItem('TicketTemplate', [
             'name' => 'Test template for assign me',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
+        $template_id = $template->getID();
         $this->assertGreaterThan(0, $template_id);
 
         // Add mandatory field (requester) to the template
-        $mandatory_field = new \TicketTemplateMandatoryField();
-        $mandatory_field_id = $mandatory_field->add([
+        $mandatory_field = $this->createItem('TicketTemplateMandatoryField', [
             'tickettemplates_id' => $template_id,
             'num' => 4, // _users_id_requester field number
         ]);
+        $mandatory_field_id = $mandatory_field->getID();
         $this->assertGreaterThan(0, $mandatory_field_id);
 
         // Create a category linked to this template
-        $category = new \ITILCategory();
-        $category_id = $category->add([
+        $category = $this->createItem('ITILCategory', [
             'name' => 'Test category for assign me',
             'tickettemplates_id_incident' => $template_id,
             'is_incident' => 1,
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
+        $category_id = $category->getID();
         $this->assertGreaterThan(0, $category_id);
 
         // Create a requester user
-        $requester = new \User();
-        $requester_id = $requester->add([
+        $requester = $this->createItem('User', [
             'name' => 'requester_test',
             'firstname' => 'Requester',
-            'lastname' => 'Test',
+            'entities_id' => 0,
         ]);
+        $requester_id = $requester->getID();
         $this->assertGreaterThan(0, $requester_id);
 
         // Create a ticket with the template and mandatory requester filled
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem('Ticket', [
             'name' => 'Test ticket for assign me',
             'content' => 'Content for test ticket',
             'itilcategories_id' => $category_id,
             '_users_id_requester' => [$requester_id],
             'status' => CommonITILObject::INCOMING,
+            'entities_id' => 0,
         ]);
+        $ticket_id = $ticket->getID();
         $this->assertGreaterThan(0, $ticket_id);
 
         // Verify the ticket was created with the requester
@@ -1185,19 +1032,29 @@ final class TicketTest extends EscaladeTestCase
 
         // Use the "Associate myself" functionality - simulate exactly what happens in ticket.form.php
         // when addme_as_actor is called
-        $ticket->getFromDB($ticket_id); // Refresh the ticket data
-        $input = array_merge(\Toolbox::addslashes_deep($ticket->fields), [
-            'id' => $ticket_id,
-            '_itil_assign' => [
-                '_type' => "user",
-                'users_id' => $current_user_id,
-                'use_notification' => 1,
-            ],
-        ]);
-
         // This should work without template validation errors
-        $result = $ticket->update($input);
-        $this->assertTrue($result);
+        $this->updateItem(
+            Ticket::class,
+            $ticket_id,
+            [
+                'id' => $ticket_id,
+                '_actors' => [
+                    'requester' => [
+                        [
+                            'itemtype' => 'User',
+                            'items_id' => $requester_id,
+                        ],
+                    ],
+                    'assign' => [
+                        [
+                            'itemtype' => 'User',
+                            'items_id' => $current_user_id,
+                            'use_notification' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        );
 
         // Verify the current user was assigned successfully
         $assigned_users_after = $ticket_user->find([
@@ -1221,8 +1078,28 @@ final class TicketTest extends EscaladeTestCase
         $this->assertEquals($requester_id, $requester_after['users_id']);
 
         // Test that calling it again doesn't create duplicate assignments
-        $result2 = $ticket->update($input);
-        $this->assertTrue($result2);
+        $this->updateItem(
+            Ticket::class,
+            $ticket_id,
+            [
+                'id' => $ticket_id,
+                '_actors' => [
+                    'requester' => [
+                        [
+                            'itemtype' => 'User',
+                            'items_id' => $requester_id,
+                        ],
+                    ],
+                    'assign' => [
+                        [
+                            'itemtype' => 'User',
+                            'items_id' => $current_user_id,
+                            'use_notification' => 1,
+                        ],
+                    ],
+                ],
+            ],
+        );
         $assigned_users_final = $ticket_user->find([
             'tickets_id' => $ticket_id,
             'type' => CommonITILActor::ASSIGN,
@@ -1244,101 +1121,94 @@ final class TicketTest extends EscaladeTestCase
      */
     public function testHistoryButtonEscalationWithMandatoryTemplateFields()
     {
-        $this->login();
-
-        // Load Escalade plugin configuration
-        $config = new PluginEscaladeConfig();
-        $conf = $config->find();
-        $conf = reset($conf);
-        $config->getFromDB($conf['id']);
-        $this->assertGreaterThan(0, $conf['id']);
-        PluginEscaladeConfig::loadInSession();
+        $this->initConfig();
 
         // Create a ticket template with mandatory requester field
-        $template = new \TicketTemplate();
-        $template_id = $template->add([
+        $template = $this->createItem('TicketTemplate', [
             'name' => 'Test template for history button',
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
+        $template_id = $template->getID();
         $this->assertGreaterThan(0, $template_id);
 
         // Add mandatory field (requester) to the template
-        $mandatory_field = new \TicketTemplateMandatoryField();
-        $mandatory_field_id = $mandatory_field->add([
+        $mandatory_field = $this->createItem('TicketTemplateMandatoryField', [
             'tickettemplates_id' => $template_id,
             'num' => 4, // _users_id_requester field number
         ]);
+        $mandatory_field_id = $mandatory_field->getID();
         $this->assertGreaterThan(0, $mandatory_field_id);
 
         // Create a category linked to this template
-        $category = new \ITILCategory();
-        $category_id = $category->add([
+        $category = $this->createItem('ITILCategory', [
             'name' => 'Test category for history button',
             'tickettemplates_id_incident' => $template_id,
             'is_incident' => 1,
             'entities_id' => 0,
             'is_recursive' => 1,
         ]);
+        $category_id = $category->getID();
         $this->assertGreaterThan(0, $category_id);
 
         // Create a requester user
-        $requester = new \User();
-        $requester_id = $requester->add([
+        $requester = $this->createItem('User', [
             'name' => 'requester_history_test',
             'firstname' => 'Requester',
-            'lastname' => 'HistoryTest',
+            'entities_id' => 0,
         ]);
+        $requester_id = $requester->getID();
         $this->assertGreaterThan(0, $requester_id);
 
         // Create first escalation group
-        $group1 = new \Group();
-        $group1_id = $group1->add([
+        $group1 = $this->createItem('Group', [
             'name' => 'First escalation group',
             'entities_id' => 0,
             'is_recursive' => 1,
             'is_assign' => 1,
         ]);
+        $group1_id = $group1->getID();
         $this->assertGreaterThan(0, $group1_id);
 
         // Create second escalation group for history
-        $group2 = new \Group();
-        $group2_id = $group2->add([
+        $group2 = $this->createItem('Group', [
             'name' => 'Second escalation group',
             'entities_id' => 0,
             'is_recursive' => 1,
             'is_assign' => 1,
         ]);
+        $group2_id = $group2->getID();
         $this->assertGreaterThan(0, $group2_id);
 
         // Create a ticket with the template and mandatory requester filled
-        $ticket = new \Ticket();
-        $ticket_id = $ticket->add([
+        $ticket = $this->createItem('Ticket', [
             'name' => 'Test ticket for history button',
             'content' => 'Content for history button test',
             'itilcategories_id' => $category_id,
             '_users_id_requester' => [$requester_id],
             'status' => CommonITILObject::INCOMING,
+            'entities_id' => 0,
         ]);
+        $ticket_id = $ticket->getID();
         $this->assertGreaterThan(0, $ticket_id);
 
         // Assign first group to the ticket
-        $group_ticket = new \Group_Ticket();
-        $group_ticket_id = $group_ticket->add([
+        $group_ticket = $this->createItem('Group_Ticket', [
             'tickets_id' => $ticket_id,
             'groups_id' => $group1_id,
             'type' => CommonITILActor::ASSIGN,
         ]);
+        $group_ticket_id = $group_ticket->getID();
         $this->assertGreaterThan(0, $group_ticket_id);
 
         // Escalate to second group (simulate the history button click)
         // This should create an escalation history entry
-        $group_ticket2 = new \Group_Ticket();
-        $group_ticket2_id = $group_ticket2->add([
+        $group_ticket2 = $this->createItem('Group_Ticket', [
             'tickets_id' => $ticket_id,
             'groups_id' => $group2_id,
             'type' => CommonITILActor::ASSIGN,
         ]);
+        $group_ticket2_id = $group_ticket2->getID();
         $this->assertGreaterThan(0, $group_ticket2_id);
 
         // Now test the history button escalation using climb_group (this reproduces the issue)

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -28,20 +28,9 @@
  * -------------------------------------------------------------------------
  */
 
-use Glpi\Application\Environment;
-use Glpi\Kernel\Kernel;
-
-use function Safe\define;
-
-define('TU_USER', 'glpi');
-define('TU_PASS', 'glpi');
 define('GLPI_LOG_DIR', __DIR__ . '/files/_logs');
 
-require_once __DIR__ . '/../../../vendor/autoload.php';
-
-require_once __DIR__ . '/../../../tests/GLPITestCase.php';
-require_once __DIR__ . '/../../../tests/DbTestCase.php';
+include_once dirname(__DIR__, 3) . '/tests/GLPITestCase.php';
+include_once dirname(__DIR__, 3) . '/tests/DbTestCase.php';
+require_once dirname(__DIR__, 3) . '/tests/bootstrap.php';
 require_once __DIR__ . '/EscaladeTestCase.php';
-
-$kernel = new Kernel(Environment::TESTING->value);
-$kernel->boot();


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

Replace legacy `add()` and `update()` calls with `createItem()` and `updateItem()` 
helper methods across all escalade test files. Standardize configuration 
initialization using `initConfig()` method from `EscaladeTestCase`.
