### PR TITLE
prevent non existing key "bypass_filter_assign_group" in ticket.class…

### DIFF
--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1264,7 +1264,7 @@ class PluginEscaladeTicket
         $condition = [
             'is_assign' => 1,
         ];
-        if ($config->fields['use_filter_assign_group'] ?? false && !($user_config->fields['bypass_filter_assign_group'] ?? false)) {
+        if (($config->fields['use_filter_assign_group'] ?? false) && !($user_config->fields['bypass_filter_assign_group'] ?? false)) {
             $condition['id'] = $groups_id_filtered;
         }
         TemplateRenderer::getInstance()->display('@escalade/escalade_form.html.twig', [


### PR DESCRIPTION
….php

fix  PHP Warning (2): Undefined array key "bypass_filter_assign_group" in /var/www/glpi/plugins/escalade/inc/ticket.class.php at line 1270

## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes # (issue number, if applicable)
- Here is a brief description of what this PR does

## Screenshots (if appropriate):
