### PR TITLE
2.9.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+## [2.9.19] - 2026-27-01
+
 ### Fixed
 
 - Handle mandatory template fields in history button escalation

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.9.19</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.19/glpi-escalade-2.9.19.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.18</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.18/glpi-escalade-2.9.18.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.18');
+define('PLUGIN_ESCALADE_VERSION', '2.9.19');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.19] - 2026-27-01

### Fixed

- Handle mandatory template fields in history button escalation
- Fix `tag` deletion before escalation using `Escalate button`
- Fix `label` button color
