### PR TITLE
fix(i18n): fix spacing and capitalization in pt_BR translation

### DIFF
--- a/locales/pt_BR.po
+++ b/locales/pt_BR.po
@@ -168,7 +168,7 @@ msgstr "Solução rejeitada, volte para o grupo"
 #: inc/ticket.class.php:563 inc/ticket.class.php:660
 #, php-format
 msgid "Escalation to the group %s."
-msgstr "Escalonamento para o grupo%s."
+msgstr "Escalonamento para o grupo %s."
 
 #: inc/ticket.class.php:1016
 msgid "Error : get old ticket"
@@ -249,7 +249,7 @@ msgstr "Reatribuir o ticket ao grupo"
 
 #: inc/history.class.php:236
 msgid "full assignation history"
-msgstr "histórico de atribuição completo"
+msgstr "Histórico de atribuição completo"
 
 #: inc/history.class.php:239
 msgid "View full history"
@@ -261,4 +261,4 @@ msgstr "Chamados para seguir (escalonados)"
 
 #: inc/history.class.php:308
 msgid "Tickets to close (escalated)"
-msgstr "Chamados para fechar (escalonado)"
+msgstr "Chamados para fechar (escalonados)"


### PR DESCRIPTION
## Checklist before requesting a review

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- Here is a brief description of what this PR does
## Description
This PR fixes some minor issues in the `pt_BR` translation file:

- Added a missing space in "Escalonamento para o grupo %s." to prevent the group name from being attached to the word "grupo".
- Fixed plural agreement in "Chamados para fechar (escalonados)".
- Capitalized "Histórico de atribuição completo" for better UI consistency.

## Motivation
Improving the user experience for Portuguese-speaking users by fixing visual and grammatical errors in the ticket timeline and history.