### PR TITLE
Fix massive action modal not showing for more than 10 associated groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Fix massive action modal not showing when a group has more than 10 associated groups
+
 ## [2.10.4] - 2026-06-24
 
 - Fix escape chars

--- a/inc/group_group.class.php
+++ b/inc/group_group.class.php
@@ -108,10 +108,6 @@ class PluginEscaladeGroup_Group extends CommonDBRelation
                     'container'        => 'mass' . self::class . $rand,
                     'itemtype'         => 'Group',
                 ];
-
-                if ($nb > 10) {
-                    $massiveactionparams['ontop'] = false;
-                }
             }
         }
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -728,15 +728,6 @@ class PluginEscaladeTicket
             return;
         }
 
-        if (
-            $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group'] != 0
-            && $_SESSION['glpi_plugins']['escalade']['config']['use_assign_user_group_creation'] != 0
-            && isset($_SESSION['plugin_escalade']['ticket_creation'])
-            && $_SESSION['plugin_escalade']['ticket_creation']
-        ) {
-            return;
-        }
-
         if ($type == CommonITILActor::ASSIGN && !$_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
             return;
         }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !45027
- In the Escalation tab of a group's form, the massive action modal failed to open once the group was linked to more than 10 groups.
- This was due to `manageGroup()` setting `ontop => false` on the massive action params when `$nb > 10`. However, `Html::showMassiveActions()` only creates the modal window when `ontop` is true (or `forcecreate` is set), while the "Actions" button is always rendered. As a result, for 11+ groups the button pointed to a modal object that was never created, so clicking it did nothing.
- Fix: Removed the `if ($nb > 10) { $massiveactionparams['ontop'] = false; }` block.