### PR TITLE
Fix: strengthen ticket escalation validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix massive action modal not showing when a group has more than 10 associated groups
+- Strengthen input validation and access checks on ticket escalation actions
 
 ## [2.10.4] - 2026-06-24
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,1 @@
+include ../../PluginsMakefile.mk

--- a/ajax/assign_me.php
+++ b/ajax/assign_me.php
@@ -36,4 +36,9 @@ if (! isset($_REQUEST['tickets_id'])) {
     throw new BadRequestHttpException();
 }
 
-PluginEscaladeTicket::assign_me((int) $_REQUEST['tickets_id']);
+$tickets_id = (int) $_REQUEST['tickets_id'];
+
+$ticket = new Ticket();
+$ticket->check($tickets_id, UPDATE);
+
+PluginEscaladeTicket::assign_me($tickets_id);

--- a/ajax/assign_me.php
+++ b/ajax/assign_me.php
@@ -39,6 +39,6 @@ if (! isset($_REQUEST['tickets_id'])) {
 $tickets_id = (int) $_REQUEST['tickets_id'];
 
 $ticket = new Ticket();
-$ticket->check($tickets_id, UPDATE);
+$ticket->check($tickets_id, Ticket::ASSIGN);
 
 PluginEscaladeTicket::assign_me($tickets_id);

--- a/ajax/cloneandlink_ticket.php
+++ b/ajax/cloneandlink_ticket.php
@@ -46,11 +46,13 @@ if (!isset($_REQUEST['tickets_id'])) {
     throw new BadRequestHttpException();
 }
 
+$tickets_id = (int) $_REQUEST['tickets_id'];
+
 $ticket = new Ticket();
 
-if ($ticket->getFromDB($_REQUEST['tickets_id'])) {
+if ($ticket->getFromDB($tickets_id)) {
     if (
-        !$ticket->can($_REQUEST['tickets_id'], READ)
+        !$ticket->can($tickets_id, READ)
         || !Ticket::canCreate()
     ) {
         throw new AccessDeniedHttpException(
@@ -58,5 +60,5 @@ if ($ticket->getFromDB($_REQUEST['tickets_id'])) {
         );
     }
 
-    PluginEscaladeTicket::cloneAndLink($_REQUEST['tickets_id']);
+    PluginEscaladeTicket::cloneAndLink($tickets_id);
 }

--- a/ajax/history.php
+++ b/ajax/history.php
@@ -34,5 +34,10 @@ Html::header_nocache();
 Session::checkLoginUser();
 
 if (isset($_REQUEST['tickets_id'])) {
-    PluginEscaladeHistory::getHistory($_REQUEST['tickets_id']);
+    $tickets_id = (int) $_REQUEST['tickets_id'];
+
+    $ticket = new Ticket();
+    $ticket->check($tickets_id, READ);
+
+    PluginEscaladeHistory::getHistory($tickets_id);
 }

--- a/front/climb_group.php
+++ b/front/climb_group.php
@@ -27,7 +27,7 @@
  * @link      https://github.com/pluginsGLPI/escalade
  * -------------------------------------------------------------------------
  */
-use Glpi\Exception\Http\AccessDeniedHttpException;
+
 use Glpi\Exception\Http\BadRequestHttpException;
 
 Session::checkLoginUser();
@@ -44,12 +44,9 @@ if (
     throw new BadRequestHttpException();
 }
 
+$tickets_id = (int) $_REQUEST['tickets_id'];
+
 $ticket = new Ticket();
-$ticket->getFromDB((int) $_REQUEST['tickets_id']);
+$ticket->check($tickets_id, UPDATE);
 
-if (!$ticket->canAssign()) {
-    throw new AccessDeniedHttpException();
-}
-
-
-PluginEscaladeTicket::climb_group((int) $_REQUEST['tickets_id'], (int) $_REQUEST['groups_id']);
+PluginEscaladeTicket::climb_group($tickets_id, (int) $_REQUEST['groups_id']);

--- a/front/climb_group.php
+++ b/front/climb_group.php
@@ -47,6 +47,6 @@ if (
 $tickets_id = (int) $_REQUEST['tickets_id'];
 
 $ticket = new Ticket();
-$ticket->check($tickets_id, UPDATE);
+$ticket->check($tickets_id, Ticket::ASSIGN);
 
 PluginEscaladeTicket::climb_group($tickets_id, (int) $_REQUEST['groups_id']);

--- a/front/group_group.form.php
+++ b/front/group_group.form.php
@@ -36,12 +36,13 @@ Html::header("escalade", $_SERVER["PHP_SELF"], "plugins", "escalade", "group_gro
 
 if (Session::haveRight('group', UPDATE)) {
     if (isset($_POST['addgroup'])) {
-        $group = new Group();
+        $group_source = new Group();
+        $group_destination = new Group();
         if (
-            !$group->getFromDB((int) $_POST['groups_id_source'])
-            || !Session::haveAccessToEntity($group->getEntityID())
-            || !$group->getFromDB((int) $_POST['groups_id_destination'])
-            || !Session::haveAccessToEntity($group->getEntityID())
+            !$group_source->getFromDB((int) $_POST['groups_id_source'])
+            || !Session::haveAccessToEntity($group_source->getEntityID())
+            || !$group_destination->getFromDB((int) $_POST['groups_id_destination'])
+            || !Session::haveAccessToEntity($group_destination->getEntityID())
         ) {
             throw new AccessDeniedHttpException();
         }

--- a/front/group_group.form.php
+++ b/front/group_group.form.php
@@ -28,20 +28,39 @@
  * -------------------------------------------------------------------------
  */
 
+use Glpi\Exception\Http\AccessDeniedHttpException;
+
 Session::checkLoginUser();
 
 Html::header("escalade", $_SERVER["PHP_SELF"], "plugins", "escalade", "group_group");
 
 if (Session::haveRight('group', UPDATE)) {
     if (isset($_POST['addgroup'])) {
+        $group = new Group();
+        if (
+            !$group->getFromDB((int) $_POST['groups_id_source'])
+            || !Session::haveAccessToEntity($group->getEntityID())
+            || !$group->getFromDB((int) $_POST['groups_id_destination'])
+            || !Session::haveAccessToEntity($group->getEntityID())
+        ) {
+            throw new AccessDeniedHttpException();
+        }
+
         $PluginEscaladeGroup_Group = new PluginEscaladeGroup_Group();
         $PluginEscaladeGroup_Group->add($_POST);
     }
 
     if (isset($_POST['deleteitem'])) {
         $PluginEscaladeGroup_Group = new PluginEscaladeGroup_Group();
+        $group = new Group();
         foreach ($_POST['delgroup'] as $id) {
-            $PluginEscaladeGroup_Group->delete(['id' => $id]);
+            if (
+                $PluginEscaladeGroup_Group->getFromDB((int) $id)
+                && $group->getFromDB((int) $PluginEscaladeGroup_Group->fields['groups_id_source'])
+                && Session::haveAccessToEntity($group->getEntityID())
+            ) {
+                $PluginEscaladeGroup_Group->delete(['id' => $id]);
+            }
         }
     }
 }

--- a/front/popup_histories.php
+++ b/front/popup_histories.php
@@ -41,8 +41,13 @@ if (!$_SESSION['glpi_plugins']['escalade']['config']['show_history']) {
     throw new AccessDeniedHttpException();
 }
 
+$tickets_id = (int) $_REQUEST['tickets_id'];
+
+$ticket = new Ticket();
+$ticket->check($tickets_id, READ);
+
 echo "<div id='page'>";
-PluginEscaladeHistory::getHistory((int) $_REQUEST['tickets_id'], true);
+PluginEscaladeHistory::getHistory($tickets_id, true);
 echo "</div>";
 
 Html::popFooter();

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -28,8 +28,6 @@
  * -------------------------------------------------------------------------
  */
 
-use Glpi\Exception\Http\AccessDeniedHttpException;
-
 Session::checkLoginUser();
 
 /** @var array $CFG_GLPI */
@@ -40,14 +38,7 @@ if (isset($_POST['escalate'])) {
     $tickets_id = (int) $_POST['tickets_id'];
 
     $ticket = new Ticket();
-    if (!$ticket->getFromDB($tickets_id)) {
-        throw new AccessDeniedHttpException();
-    }
-
-    // Same right check as in PluginEscaladeTicket::addToTimeline()
-    if (!$ticket->canAssign()) {
-        throw new AccessDeniedHttpException();
-    }
+    $ticket->check($tickets_id, UPDATE);
 
     PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -38,7 +38,7 @@ if (isset($_POST['escalate'])) {
     $tickets_id = (int) $_POST['tickets_id'];
 
     $ticket = new Ticket();
-    $ticket->check($tickets_id, UPDATE);
+    $ticket->check($tickets_id, Ticket::ASSIGN);
 
     PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
 

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -246,7 +246,7 @@ class PluginEscaladeHistory extends CommonDBTM
     {
 
         if (!$group->can($group->fields['id'], READ)) {
-            return $group->getNameID(true);
+            return '';
         }
 
         $link_item = $group->getFormURL();

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1005,6 +1005,9 @@ class PluginEscaladeTicket
         /** @var DBmysql $DB */
         global $DB;
 
+        // Enforce integer type before interpolation in the raw SQL below (SQL injection guard)
+        $tickets_id = (int) $tickets_id;
+
         //get old ticket
         $ticket = new Ticket();
         if (!$ticket->getFromDB($tickets_id)) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A
- Adds stricter input validation and access checks across the ticket escalation actions (self-assign, group climb, clone and link, escalation history, group mapping).
These actions now consistently verify the ticket ID and the caller's rights before acting on the data.

## Screenshots (if appropriate):
