### PR TITLE
Fix group removal on escalation only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix infinite loop / Gateway Timeout when a ticket's assigned technician and assigned group are changed simultaneously, caused by a synchronous actor removal during `pre_item_update()`
+- Fixed group reassignment to remove previously assigned groups only when using the Escalade reassignment action
 
 ## [2.10.6] - 2026-07-31
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -44,7 +44,14 @@ if (isset($_POST['escalate'])) {
         throw new AccessDeniedHttpException();
     }
 
-    PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
+    // Mark this operation as a real escalation from the Escalade form.
+    $_SESSION['plugin_escalade']['is_escalation'] = true;
+
+    try {
+        PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
+    } finally {
+        unset($_SESSION['plugin_escalade']['is_escalation']);
+    }
 
     $track = new Ticket();
 

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -160,7 +160,10 @@ class PluginEscaladeHistory extends CommonDBTM
         $group = new Group();
 
         $history = new self();
-        $found = $history->find(['tickets_id' => $tickets_id], "date_mod DESC");
+        $found = $history->find(
+        ['tickets_id' => $tickets_id],
+        ['date_mod DESC', 'id DESC'],
+    );
         $nb_histories = count($found);
 
         //remove first line (current assign)

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -161,13 +161,36 @@ class PluginEscaladeHistory extends CommonDBTM
 
         $history = new self();
         $found = $history->find(
-        ['tickets_id' => $tickets_id],
-        ['date_mod DESC', 'id DESC'],
-    );
+            ['tickets_id' => $tickets_id],
+            ['date_mod DESC', 'id DESC'],
+        );
         $nb_histories = count($found);
 
         //remove first line (current assign)
         $first_group = array_shift($found);
+
+        // Do not display a group as a previous assignment while it is still
+        // assigned to the ticket. Its history entry stays in the database and
+        // becomes visible after a real reassignment removes the group.
+        $group_ticket = new Group_Ticket();
+        $currently_assigned = $group_ticket->find([
+            'tickets_id' => $tickets_id,
+            'type'       => CommonITILActor::ASSIGN,
+        ]);
+
+        $currently_assigned_ids = array_map(
+            static fn(array $actor): int => (int) $actor['groups_id'],
+            $currently_assigned,
+        );
+
+        $found = array_filter(
+            $found,
+            static fn(array $history_entry): bool => !in_array(
+                (int) $history_entry['groups_id'],
+                $currently_assigned_ids,
+                true,
+            ),
+        );
 
         if ($full_history) {
             //show 1st group

--- a/inc/history.class.php
+++ b/inc/history.class.php
@@ -164,33 +164,34 @@ class PluginEscaladeHistory extends CommonDBTM
             ['tickets_id' => $tickets_id],
             ['date_mod DESC', 'id DESC'],
         );
-        $nb_histories = count($found);
 
         //remove first line (current assign)
         $first_group = array_shift($found);
 
-        // Do not display a group as a previous assignment while it is still
-        // assigned to the ticket. Its history entry stays in the database and
-        // becomes visible after a real reassignment removes the group.
-        $group_ticket = new Group_Ticket();
-        $currently_assigned = $group_ticket->find([
-            'tickets_id' => $tickets_id,
-            'type'       => CommonITILActor::ASSIGN,
-        ]);
+        if (!$full_history) {
+            // Hide still-assigned groups from the compact widget only: the full popup stays a complete audit trail.
+            $group_ticket = new Group_Ticket();
+            $currently_assigned = $group_ticket->find([
+                'tickets_id' => $tickets_id,
+                'type'       => CommonITILActor::ASSIGN,
+            ]);
 
-        $currently_assigned_ids = array_map(
-            static fn(array $actor): int => (int) $actor['groups_id'],
-            $currently_assigned,
-        );
+            $currently_assigned_ids = array_map(
+                static fn(array $actor): int => (int) $actor['groups_id'],
+                $currently_assigned,
+            );
 
-        $found = array_filter(
-            $found,
-            static fn(array $history_entry): bool => !in_array(
-                (int) $history_entry['groups_id'],
-                $currently_assigned_ids,
-                true,
-            ),
-        );
+            $found = array_filter(
+                $found,
+                static fn(array $history_entry): bool => !in_array(
+                    (int) $history_entry['groups_id'],
+                    $currently_assigned_ids,
+                    true,
+                ),
+            );
+        }
+
+        $nb_histories = count($found) + 1;
 
         if ($full_history) {
             //show 1st group

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -546,108 +546,9 @@ class PluginEscaladeTicket
                 !empty($_SESSION['plugin_escalade']['is_escalation'])
                 || !empty($_SESSION['plugin_escalade']['climb_group'])
                 || !empty($_SESSION['plugin_escalade']['auto_group_assignment'])
+                || !empty($_SESSION['plugin_escalade']['category_group_reassignment'])
             )
         ) {
-
-            // Save ALL currently assigned groups in Escalade history before
-            // the reassignment removes them. Normal GLPI assignments are not
-            // written to Escalade history until a real reassignment happens.
-            if ($_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true) {
-                $group_ticket_history = new Group_Ticket();
-                $assigned_before = $group_ticket_history->find([
-                    'tickets_id' => $tickets_id,
-                    'type'       => CommonITILActor::ASSIGN,
-                ]);
-
-                // Keep assignment order stable.
-                uasort(
-                    $assigned_before,
-                    static function (array $a, array $b): int {
-                        return ((int) $a['id']) <=> ((int) $b['id']);
-                    },
-                );
-
-                $history = new PluginEscaladeHistory();
-
-                // Find the group already represented as the current group
-                // in Escalade history. Do not add it twice.
-                $existing_history = $history->find(
-                    ['tickets_id' => $tickets_id],
-                    ['date_mod DESC', 'id DESC'],
-                );
-
-                $last_history = reset($existing_history);
-                $previous_history_group = $last_history !== false
-                    ? (int) $last_history['groups_id']
-                    : 0;
-
-                // Add all groups that are about to disappear.
-                foreach ($assigned_before as $assigned_group) {
-                    $previous_group_id = (int) $assigned_group['groups_id'];
-
-                    // The new destination group will be written last.
-                    if ($previous_group_id === (int) $groups_id) {
-                        continue;
-                    }
-
-                    // This group is already the current entry in history.
-                    if ($previous_group_id === $previous_history_group) {
-                        continue;
-                    }
-
-                    $counter = 0;
-
-                    if ($previous_history_group > 0) {
-                        $last_same_history = PluginEscaladeHistory::getLastHistoryForTicketAndGroup(
-                            $tickets_id,
-                            $previous_group_id,
-                            $previous_history_group,
-                        );
-
-                        if (
-                            $last_same_history !== false
-                            && count($last_same_history->fields) > 0
-                        ) {
-                            $counter = ((int) $last_same_history->fields['counter']) + 1;
-                        }
-                    }
-
-                    $history->add([
-                        'tickets_id'         => $tickets_id,
-                        'groups_id'          => $previous_group_id,
-                        'groups_id_previous' => $previous_history_group,
-                        'counter'            => $counter,
-                    ]);
-
-                    $previous_history_group = $previous_group_id;
-                }
-
-                // The destination group MUST be the newest history row.
-                // getHistory() treats the newest row as the active group.
-                $counter = 0;
-
-                if ($previous_history_group > 0) {
-                    $last_same_history = PluginEscaladeHistory::getLastHistoryForTicketAndGroup(
-                        $tickets_id,
-                        $groups_id,
-                        $previous_history_group,
-                    );
-
-                    if (
-                        $last_same_history !== false
-                        && count($last_same_history->fields) > 0
-                    ) {
-                        $counter = ((int) $last_same_history->fields['counter']) + 1;
-                    }
-                }
-
-                $history->add([
-                    'tickets_id'         => $tickets_id,
-                    'groups_id'          => $groups_id,
-                    'groups_id_previous' => $previous_history_group,
-                    'counter'            => $counter,
-                ]);
-            }
 
             $all_actors = self::getTicketFieldsWithActors($tickets_id, $groups_id);
 
@@ -697,7 +598,6 @@ class PluginEscaladeTicket
             PluginEscaladeTicket::addHistoryOnAddGroup($item);
         }
 
-        // The config is checked in the function.
 
         if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE) {
             $ticket = new Ticket();
@@ -707,8 +607,10 @@ class PluginEscaladeTicket
             ]);
         }
 
-        // Escalade history is recorded before old assigned groups are removed.
-        // This allows all previous groups to remain visible in visual history.
+        if ($_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true) {
+            $item->input['actortype'] = $item->fields['type'];
+            PluginEscaladeTicket::addHistoryOnAddGroup($item);
+        }
 
         $comment = $_POST['comment'] ?? '';
         $group = new Group();
@@ -1127,7 +1029,14 @@ class PluginEscaladeTicket
             $group_found = $group_ticket->find($group_condition);
             if (empty($group_found)) {
                 //add group to ticket
-                $group_ticket->add($group_condition);
+                $_SESSION['plugin_escalade']['category_group_reassignment'] = true;
+
+                try {
+                    $group_ticket->add($group_condition);
+                } finally {
+                    unset($_SESSION['plugin_escalade']['category_group_reassignment']);
+                }
+
                 //remove old group if needed
                 if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] && isset($item->input['_groups_id_assign'])) {
                     foreach ($item->input['_groups_id_assign'] as $idActor => $actor) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -535,22 +535,19 @@ class PluginEscaladeTicket
         $tickets_id = $item->fields['tickets_id'];
         $groups_id = $item->fields['groups_id'];
 
-        // Normal GLPI group assignment is not an Escalade action.
-        // Only the Escalade reassignment button or visual history action
-        // may run removal/history/task logic.
-        if (
-            empty($_SESSION['plugin_escalade']['is_escalation'])
-            && empty($_SESSION['plugin_escalade']['climb_group'])
-        ) {
-            return $item;
-        }
-
         // Fire business rules before removing old groups: pass _actors with only the new
         // group so GLPI detects old groups as deleted and rules see the final state.
         // getFromDB() is required first so isNewItem() returns false and deleted-actor
         // detection runs. _plugin_escalade_rules_only skips escalade logic in pre_item_update.
         // Safety net in case updateActors() above did not already remove old groups.
-        if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
+        if (
+            $_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true
+            && (
+                !empty($_SESSION['plugin_escalade']['is_escalation'])
+                || !empty($_SESSION['plugin_escalade']['climb_group'])
+                || !empty($_SESSION['plugin_escalade']['auto_group_assignment'])
+            )
+        ) {
 
             // Save ALL currently assigned groups in Escalade history before
             // the reassignment removes them. Normal GLPI assignments are not
@@ -689,6 +686,18 @@ class PluginEscaladeTicket
         $keep_users_id = $_SESSION['plugin_escalade']['keep_new_assign_users'][$tickets_id] ?? false;
         unset($_SESSION['plugin_escalade']['keep_new_assign_users'][$tickets_id]);
         self::removeAssignUsers($item, $keep_users_id);
+        // Keep the initial assigned group in Escalade history when the
+        // ticket is created. Normal manual group additions must not be
+        // treated as Escalade reassignments.
+        if (
+            !empty($_SESSION['plugin_escalade']['ticket_creation'])
+            && $_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true
+        ) {
+            $item->input['actortype'] = $item->fields['type'];
+            PluginEscaladeTicket::addHistoryOnAddGroup($item);
+        }
+
+        // The config is checked in the function.
 
         if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE) {
             $ticket = new Ticket();
@@ -1010,12 +1019,19 @@ class PluginEscaladeTicket
             //prevent user removal
             $_SESSION['plugin_escalade']['keep_users'][$item->fields['users_id']]
                 = $item->fields['users_id'];
-            //add new group to ticket
-            $group_ticket->add([
-                'tickets_id' => $tickets_id,
-                'groups_id'  => $groups_id,
-                'type'       => CommonITILActor::ASSIGN,
-            ]);
+
+            // Mark this group assignment as an automatic Escalade assignment.
+            $_SESSION['plugin_escalade']['auto_group_assignment'] = true;
+
+            try {
+                $group_ticket->add([
+                    'tickets_id' => $tickets_id,
+                    'groups_id'  => $groups_id,
+                    'type'       => CommonITILActor::ASSIGN,
+                ]);
+            } finally {
+                unset($_SESSION['plugin_escalade']['auto_group_assignment']);
+            }
         } elseif ($_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
             self::removeAssignGroups($tickets_id);
         }

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -535,12 +535,123 @@ class PluginEscaladeTicket
         $tickets_id = $item->fields['tickets_id'];
         $groups_id = $item->fields['groups_id'];
 
+        // Normal GLPI group assignment is not an Escalade action.
+        // Only the Escalade reassignment button or visual history action
+        // may run removal/history/task logic.
+        if (
+            empty($_SESSION['plugin_escalade']['is_escalation'])
+            && empty($_SESSION['plugin_escalade']['climb_group'])
+        ) {
+            return $item;
+        }
+
         // Fire business rules before removing old groups: pass _actors with only the new
         // group so GLPI detects old groups as deleted and rules see the final state.
         // getFromDB() is required first so isNewItem() returns false and deleted-actor
         // detection runs. _plugin_escalade_rules_only skips escalade logic in pre_item_update.
         // Safety net in case updateActors() above did not already remove old groups.
         if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
+
+            // Save ALL currently assigned groups in Escalade history before
+            // the reassignment removes them. Normal GLPI assignments are not
+            // written to Escalade history until a real reassignment happens.
+            if ($_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true) {
+                $group_ticket_history = new Group_Ticket();
+                $assigned_before = $group_ticket_history->find([
+                    'tickets_id' => $tickets_id,
+                    'type'       => CommonITILActor::ASSIGN,
+                ]);
+
+                // Keep assignment order stable.
+                uasort(
+                    $assigned_before,
+                    static function (array $a, array $b): int {
+                        return ((int) $a['id']) <=> ((int) $b['id']);
+                    },
+                );
+
+                $history = new PluginEscaladeHistory();
+
+                // Find the group already represented as the current group
+                // in Escalade history. Do not add it twice.
+                $existing_history = $history->find(
+                    ['tickets_id' => $tickets_id],
+                    ['date_mod DESC', 'id DESC'],
+                );
+
+                $last_history = reset($existing_history);
+                $previous_history_group = $last_history !== false
+                    ? (int) $last_history['groups_id']
+                    : 0;
+
+                // Add all groups that are about to disappear.
+                foreach ($assigned_before as $assigned_group) {
+                    $previous_group_id = (int) $assigned_group['groups_id'];
+
+                    // The new destination group will be written last.
+                    if ($previous_group_id === (int) $groups_id) {
+                        continue;
+                    }
+
+                    // This group is already the current entry in history.
+                    if ($previous_group_id === $previous_history_group) {
+                        continue;
+                    }
+
+                    $counter = 0;
+
+                    if ($previous_history_group > 0) {
+                        $last_same_history = PluginEscaladeHistory::getLastHistoryForTicketAndGroup(
+                            $tickets_id,
+                            $previous_group_id,
+                            $previous_history_group,
+                        );
+
+                        if (
+                            $last_same_history !== false
+                            && count($last_same_history->fields) > 0
+                        ) {
+                            $counter = ((int) $last_same_history->fields['counter']) + 1;
+                        }
+                    }
+
+                    $history->add([
+                        'tickets_id'         => $tickets_id,
+                        'groups_id'          => $previous_group_id,
+                        'groups_id_previous' => $previous_history_group,
+                        'counter'            => $counter,
+                    ]);
+
+                    $previous_history_group = $previous_group_id;
+                }
+
+                // The destination group MUST be the newest history row.
+                // getHistory() treats the newest row as the active group.
+                $counter = 0;
+
+                if ($previous_history_group > 0) {
+                    $last_same_history = PluginEscaladeHistory::getLastHistoryForTicketAndGroup(
+                        $tickets_id,
+                        $groups_id,
+                        $previous_history_group,
+                    );
+
+                    if (
+                        $last_same_history !== false
+                        && count($last_same_history->fields) > 0
+                    ) {
+                        $counter = ((int) $last_same_history->fields['counter']) + 1;
+                    }
+                }
+
+                $history->add([
+                    'tickets_id'         => $tickets_id,
+                    'groups_id'          => $groups_id,
+                    'groups_id_previous' => $previous_history_group,
+                    'counter'            => $counter,
+                ]);
+            }
+
             $all_actors = self::getTicketFieldsWithActors($tickets_id, $groups_id);
 
             // Keep only the new group in the assign list (drop old ones).
@@ -587,10 +698,8 @@ class PluginEscaladeTicket
             ]);
         }
 
-        if ($_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true) {
-            $item->input['actortype'] = $item->fields['type'];
-            PluginEscaladeTicket::addHistoryOnAddGroup($item);
-        }
+        // Escalade history is recorded before old assigned groups are removed.
+        // This allows all previous groups to remain visible in visual history.
 
         $comment = $_POST['comment'] ?? '';
         $group = new Group();
@@ -707,12 +816,22 @@ class PluginEscaladeTicket
             // and wipes them from the ticket regardless of the
             // "Remove requester(s) on escalation" plugin config.
             $ticket = new Ticket();
-            $ticket->update([
-                'id'        => $tickets_id,
-                '_actors'   => self::getTicketFieldsWithActors($tickets_id, $groups_id),
-                'actortype' => CommonITILActor::ASSIGN,
-                'groups_id' => $groups_id,
-            ]);
+
+            // Mark this assignment as an actual Escalade reassignment.
+            // processAfterAddGroup() also runs for normal GLPI group assignments,
+            // so old groups must only be removed for this specific action.
+            $_SESSION['plugin_escalade']['climb_group'] = true;
+
+            try {
+                $ticket->update([
+                    'id'        => $tickets_id,
+                    '_actors'   => self::getTicketFieldsWithActors($tickets_id, $groups_id),
+                    'actortype' => CommonITILActor::ASSIGN,
+                    'groups_id' => $groups_id,
+                ]);
+            } finally {
+                unset($_SESSION['plugin_escalade']['climb_group']);
+            }
         }
 
         if (!$no_redirect) {

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -587,16 +587,6 @@ class PluginEscaladeTicket
         $keep_users_id = $_SESSION['plugin_escalade']['keep_new_assign_users'][$tickets_id] ?? false;
         unset($_SESSION['plugin_escalade']['keep_new_assign_users'][$tickets_id]);
         self::removeAssignUsers($item, $keep_users_id);
-        // Keep the initial assigned group in Escalade history when the
-        // ticket is created. Normal manual group additions must not be
-        // treated as Escalade reassignments.
-        if (
-            !empty($_SESSION['plugin_escalade']['ticket_creation'])
-            && $_SESSION['glpi_plugins']['escalade']['config']['show_history'] == true
-        ) {
-            $item->input['actortype'] = $item->fields['type'];
-            PluginEscaladeTicket::addHistoryOnAddGroup($item);
-        }
 
 
         if ($_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'] != self::MANAGED_BY_CORE) {

--- a/tests/EscaladeTestCase.php
+++ b/tests/EscaladeTestCase.php
@@ -176,7 +176,19 @@ abstract class EscaladeTestCase extends DbTestCase
             ],
         );
         $_POST['comment'] = $options['comment'] ?? 'Default comment';
-        PluginEscaladeTicket::timelineClimbAction($group->getID(), $ticket->getID(), $options);
+
+        $_SESSION['plugin_escalade']['is_escalation'] = true;
+
+        try {
+            PluginEscaladeTicket::timelineClimbAction(
+                $group->getID(),
+                $ticket->getID(),
+                $options,
+            );
+        } finally {
+            unset($_SESSION['plugin_escalade']['is_escalation']);
+        }
+
         $ticketgroup = new Group_Ticket();
         $is_escalate = $ticketgroup->getFromDBByCrit([
             'tickets_id' => $ticket->getID(),

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -46,7 +46,6 @@ use User;
 
 final class GroupEscalationTest extends EscaladeTestCase
 {
-
     /**
      * Standard GLPI group assignment must not remove previously assigned groups.
      */
@@ -826,9 +825,9 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
 
         $history = new PluginEscaladeHistory();
-        $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID()])));
+        $this->assertEquals(2, count($history->find(['tickets_id' => $ticket->getID()])));
         $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group1->getID()])));
-        $this->assertEquals(0, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID()])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID()])));
 
         // Update escalade config
         $this->initConfig([
@@ -847,7 +846,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
 
         $history = new PluginEscaladeHistory();
-        $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID()])));
+        $this->assertEquals(2, count($history->find(['tickets_id' => $ticket->getID()])));
         $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group1->getID()])));
     }
 

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -37,6 +37,7 @@ use Group_Ticket;
 use Notification;
 use NotificationTarget;
 use PluginEscaladeHistory;
+use PluginEscaladeTicket;
 use PluginEscaladeNotification;
 use QueuedNotification;
 use Ticket;
@@ -45,6 +46,154 @@ use User;
 
 final class GroupEscalationTest extends EscaladeTestCase
 {
+
+    /**
+     * Standard GLPI group assignment must not remove previously assigned groups.
+     */
+    public function testStandardGroupAssignmentKeepsExistingGroups(): void
+    {
+        $this->initConfig([
+            'remove_group' => 1,
+            'show_history' => 1,
+        ]);
+
+        $group1 = $this->createGroup('standard_group_1_' . uniqid());
+        $group2 = $this->createGroup('standard_group_2_' . uniqid());
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name' => 'Standard group assignment regression test',
+            'content' => '',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group1->getID(),
+                        'itemtype' => 'Group',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Simulate adding another group from the standard GLPI actors field.
+        $this->createItem(Group_Ticket::class, [
+            'tickets_id' => $ticket->getID(),
+            'groups_id' => $group2->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]);
+
+        $group_ticket = new Group_Ticket();
+        $assigned_groups = $group_ticket->find([
+            'tickets_id' => $ticket->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]);
+
+        $this->assertCount(2, $assigned_groups);
+
+        $this->assertCount(1, $group_ticket->find([
+            'tickets_id' => $ticket->getID(),
+            'groups_id' => $group1->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]));
+
+        $this->assertCount(1, $group_ticket->find([
+            'tickets_id' => $ticket->getID(),
+            'groups_id' => $group2->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]));
+    }
+
+    /**
+     * A real Escalade reassignment must remove old groups while preserving
+     * every previously assigned group in the visual assignment history.
+     */
+    public function testEscaladeReassignmentPreservesAllGroupsInHistory(): void
+    {
+        $this->initConfig([
+            'remove_group' => 1,
+            'show_history' => 1,
+        ]);
+
+        $group1 = $this->createGroup('history_group_1_' . uniqid());
+        $group2 = $this->createGroup('history_group_2_' . uniqid());
+        $group3 = $this->createGroup('history_group_3_' . uniqid());
+        $group4 = $this->createGroup('history_destination_' . uniqid());
+
+        $ticket = $this->createItem(Ticket::class, [
+            'name' => 'Multiple group history regression test',
+            'content' => '',
+            '_actors' => [
+                'assign' => [
+                    [
+                        'items_id' => $group1->getID(),
+                        'itemtype' => 'Group',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Add groups through the normal GLPI assignment mechanism.
+        foreach ([$group2, $group3] as $group) {
+            $this->createItem(Group_Ticket::class, [
+                'tickets_id' => $ticket->getID(),
+                'groups_id' => $group->getID(),
+                'type' => CommonITILActor::ASSIGN,
+            ]);
+        }
+
+        $group_ticket = new Group_Ticket();
+
+        $this->assertCount(3, $group_ticket->find([
+            'tickets_id' => $ticket->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]));
+
+        // Simulate the real Escalade button.
+        $_SESSION['plugin_escalade']['is_escalation'] = true;
+        $_POST['comment'] = 'Regression test escalation';
+
+        try {
+            PluginEscaladeTicket::timelineClimbAction(
+                $group4->getID(),
+                $ticket->getID(),
+                [
+                    'ticket_details' => [
+                        'id' => $ticket->getID(),
+                    ],
+                ],
+            );
+        } finally {
+            unset($_SESSION['plugin_escalade']['is_escalation']);
+            unset($_POST['comment']);
+        }
+
+        // Only the destination group must remain assigned.
+        $assigned_groups = $group_ticket->find([
+            'tickets_id' => $ticket->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]);
+
+        $this->assertCount(1, $assigned_groups);
+        $assigned_group = reset($assigned_groups);
+        $this->assertEquals($group4->getID(), $assigned_group['groups_id']);
+
+        // All groups involved in the reassignment must remain visible
+        // in Escalade history.
+        $history = new PluginEscaladeHistory();
+
+        foreach ([$group1, $group2, $group3, $group4] as $group) {
+            $this->assertGreaterThanOrEqual(
+                1,
+                count($history->find([
+                    'tickets_id' => $ticket->getID(),
+                    'groups_id' => $group->getID(),
+                ])),
+                sprintf(
+                    'Group %d is missing from Escalade history',
+                    $group->getID(),
+                ),
+            );
+        }
+    }
+
     public function testTechGroupAttributionUpdateTicket()
     {
         $this->initConfig([
@@ -677,9 +826,9 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
 
         $history = new PluginEscaladeHistory();
-        $this->assertEquals(2, count($history->find(['tickets_id' => $ticket->getID()])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID()])));
         $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group1->getID()])));
-        $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID()])));
+        $this->assertEquals(0, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group2->getID()])));
 
         // Update escalade config
         $this->initConfig([
@@ -698,7 +847,7 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
 
         $history = new PluginEscaladeHistory();
-        $this->assertEquals(2, count($history->find(['tickets_id' => $ticket->getID()])));
+        $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID()])));
         $this->assertEquals(1, count($history->find(['tickets_id' => $ticket->getID(), 'groups_id' => $group1->getID()])));
     }
 

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -79,21 +79,18 @@ final class GroupEscalationTest extends EscaladeTestCase
             'type' => CommonITILActor::ASSIGN,
         ]);
 
-        $group_ticket = new Group_Ticket();
-        $assigned_groups = $group_ticket->find([
+        $this->assertEquals(2, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'type' => CommonITILActor::ASSIGN,
-        ]);
+        ]));
 
-        $this->assertCount(2, $assigned_groups);
-
-        $this->assertCount(1, $group_ticket->find([
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'groups_id' => $group1->getID(),
             'type' => CommonITILActor::ASSIGN,
         ]));
 
-        $this->assertCount(1, $group_ticket->find([
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'groups_id' => $group2->getID(),
             'type' => CommonITILActor::ASSIGN,
@@ -140,7 +137,7 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         $group_ticket = new Group_Ticket();
 
-        $this->assertCount(3, $group_ticket->find([
+        $this->assertEquals(3, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'type' => CommonITILActor::ASSIGN,
         ]));
@@ -165,12 +162,16 @@ final class GroupEscalationTest extends EscaladeTestCase
         }
 
         // Only the destination group must remain assigned.
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
+            'tickets_id' => $ticket->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]));
+
         $assigned_groups = $group_ticket->find([
             'tickets_id' => $ticket->getID(),
             'type' => CommonITILActor::ASSIGN,
         ]);
 
-        $this->assertCount(1, $assigned_groups);
         $assigned_group = reset($assigned_groups);
         $this->assertEquals($group4->getID(), $assigned_group['groups_id']);
 
@@ -228,8 +229,9 @@ final class GroupEscalationTest extends EscaladeTestCase
         );
 
         // Check no group linked to the ticket
-        $ticket_group = new Group_Ticket();
-        $this->assertEquals(0, count($ticket_group->find(['tickets_id' => $ticket->getID()])));
+        $this->assertEquals(0, countElementsInTable(Group_Ticket::getTable(), [
+            'tickets_id' => $ticket->getID(),
+        ]));
 
         // Update ticket with a technician
         $this->updateItem(Ticket::class, $ticket->getID(), [
@@ -250,8 +252,10 @@ final class GroupEscalationTest extends EscaladeTestCase
         ]);
 
         $ticket_group2 = new Group_Ticket();
-        // Check only one groupe linked to the ticket
-        $this->assertEquals(1, count($ticket_group2->find(['tickets_id' => $ticket->getID()])));
+        // Check only one group linked to the ticket
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
+            'tickets_id' => $ticket->getID(),
+        ]));
 
         $ticket_group2->getFromDBByCrit([
             'tickets_id' => $ticket->getID(),

--- a/tests/Units/TicketTest.php
+++ b/tests/Units/TicketTest.php
@@ -355,14 +355,14 @@ final class TicketTest extends EscaladeTestCase
             ],
         ]);
 
-        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id, 'type' => CommonITILActor::ASSIGN])));
 
         $this->updateItem('Ticket', $ticket_id, [
             'status' => CommonITILObject::WAITING,
         ]);
 
-        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
+        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id, 'type' => CommonITILActor::ASSIGN])));
     }
 


### PR DESCRIPTION
Previously, when the "Remove previously assigned group when assigning a group" option was enabled, adding a group through the standard GLPI actors field also removed all previously assigned groups.

Now, previously assigned groups are removed only when the Escalade reassignment action is used. Adding groups through the standard GLPI actors field keeps the existing assigned groups.

The visual group assignment history has also been updated so that all groups that were assigned before a reassignment remain visible in the history.
