### PR TITLE
2.10.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [2.10.7] - 2026-08-31
 
 ### Fixed
 

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.10.7</num>
+         <compatibility>~11.0.0</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.10.7/glpi-escalade-2.10.7.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.10.6</num>
          <compatibility>~11.0.0</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.10.6/glpi-escalade-2.10.6.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.10.6');
+define('PLUGIN_ESCALADE_VERSION', '2.10.7');
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "11.0.0");
 // Maximum GLPI version, exclusive


### PR DESCRIPTION
## [2.10.7] - 2026-08-31

### Fixed

- Fix infinite loop / Gateway Timeout when a ticket's assigned technician and assigned group are changed simultaneously, caused by a synchronous actor removal during `pre_item_update()`
- Fixed group reassignment to remove previously assigned groups only when using the Escalade reassignment action
- Fixed `_plugin_escalade_rules_only` being ignored on group assignments, so callers could not opt out of escalade's automatic processing
- Use item-scoped access check on escalation routes