### PR TITLE
2.9.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [2.9.21] - 2026-09-07
 
 ### Fixed
 

--- a/escalade.xml
+++ b/escalade.xml
@@ -62,6 +62,11 @@ Elle ajoute les fonctionnalités suivantes :
    </authors>
    <versions>
       <version>
+         <num>2.9.21</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.21/glpi-escalade-2.9.21.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.9.20</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/escalade/releases/download/2.9.20/glpi-escalade-2.9.20.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_ESCALADE_VERSION', '2.9.20');
+define('PLUGIN_ESCALADE_VERSION', '2.9.21');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_ESCALADE_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.9.21] - 2026-09-07

### Fixed

- Use item-scoped access check on escalation routes

Need : https://github.com/pluginsGLPI/escalade/pull/494