### PR TITLE
fix(core): fix group escalation when using actor fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fix group escalation when using actor fields
+
 ## [2.10.7] - 2026-08-31
 
 ### Fixed

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -45,14 +45,8 @@ if (isset($_POST['escalate'])) {
         throw new AccessDeniedHttpException();
     }
 
-    // Mark this operation as a real escalation from the Escalade form.
-    $_SESSION['plugin_escalade']['is_escalation'] = true;
 
-    try {
-        PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
-    } finally {
-        unset($_SESSION['plugin_escalade']['is_escalation']);
-    }
+    PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
 
     $track = new Ticket();
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -548,16 +548,7 @@ class PluginEscaladeTicket
         // getFromDB() is required first so isNewItem() returns false and deleted-actor
         // detection runs. _plugin_escalade_rules_only skips escalade logic in pre_item_update.
         // Safety net in case updateActors() above did not already remove old groups.
-        if (
-            $_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true
-            && (
-                !empty($_SESSION['plugin_escalade']['is_escalation'])
-                || !empty($_SESSION['plugin_escalade']['climb_group'])
-                || !empty($_SESSION['plugin_escalade']['auto_group_assignment'])
-                || !empty($_SESSION['plugin_escalade']['category_group_reassignment'])
-            )
-        ) {
-
+        if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] == true) {
             $all_actors = self::getTicketFieldsWithActors($tickets_id, $groups_id);
 
             // Keep only the new group in the assign list (drop old ones).
@@ -726,21 +717,12 @@ class PluginEscaladeTicket
             // "Remove requester(s) on escalation" plugin config.
             $ticket = new Ticket();
 
-            // Mark this assignment as an actual Escalade reassignment.
-            // processAfterAddGroup() also runs for normal GLPI group assignments,
-            // so old groups must only be removed for this specific action.
-            $_SESSION['plugin_escalade']['climb_group'] = true;
-
-            try {
-                $ticket->update([
-                    'id'        => $tickets_id,
-                    '_actors'   => self::getTicketFieldsWithActors($tickets_id, $groups_id),
-                    'actortype' => CommonITILActor::ASSIGN,
-                    'groups_id' => $groups_id,
-                ]);
-            } finally {
-                unset($_SESSION['plugin_escalade']['climb_group']);
-            }
+            $ticket->update([
+                'id'        => $tickets_id,
+                '_actors'   => self::getTicketFieldsWithActors($tickets_id, $groups_id),
+                'actortype' => CommonITILActor::ASSIGN,
+                'groups_id' => $groups_id,
+            ]);
         }
 
         if (!$no_redirect) {
@@ -920,18 +902,11 @@ class PluginEscaladeTicket
             $_SESSION['plugin_escalade']['keep_users'][$item->fields['users_id']]
                 = $item->fields['users_id'];
 
-            // Mark this group assignment as an automatic Escalade assignment.
-            $_SESSION['plugin_escalade']['auto_group_assignment'] = true;
-
-            try {
-                $group_ticket->add([
-                    'tickets_id' => $tickets_id,
-                    'groups_id'  => $groups_id,
-                    'type'       => CommonITILActor::ASSIGN,
-                ]);
-            } finally {
-                unset($_SESSION['plugin_escalade']['auto_group_assignment']);
-            }
+            $group_ticket->add([
+                'tickets_id' => $tickets_id,
+                'groups_id'  => $groups_id,
+                'type'       => CommonITILActor::ASSIGN,
+            ]);
         } elseif ($_SESSION['glpi_plugins']['escalade']['config']['remove_tech']) {
             self::removeAssignGroups($tickets_id);
         }
@@ -1027,13 +1002,8 @@ class PluginEscaladeTicket
             $group_found = $group_ticket->find($group_condition);
             if (empty($group_found)) {
                 //add group to ticket
-                $_SESSION['plugin_escalade']['category_group_reassignment'] = true;
 
-                try {
-                    $group_ticket->add($group_condition);
-                } finally {
-                    unset($_SESSION['plugin_escalade']['category_group_reassignment']);
-                }
+                $group_ticket->add($group_condition);
 
                 //remove old group if needed
                 if ($_SESSION['glpi_plugins']['escalade']['config']['remove_group'] && isset($item->input['_groups_id_assign'])) {

--- a/tests/EscaladeTestCase.php
+++ b/tests/EscaladeTestCase.php
@@ -177,17 +177,11 @@ abstract class EscaladeTestCase extends DbTestCase
         );
         $_POST['comment'] = $options['comment'] ?? 'Default comment';
 
-        $_SESSION['plugin_escalade']['is_escalation'] = true;
-
-        try {
-            PluginEscaladeTicket::timelineClimbAction(
-                $group->getID(),
-                $ticket->getID(),
-                $options,
-            );
-        } finally {
-            unset($_SESSION['plugin_escalade']['is_escalation']);
-        }
+        PluginEscaladeTicket::timelineClimbAction(
+            $group->getID(),
+            $ticket->getID(),
+            $options,
+        );
 
         $ticketgroup = new Group_Ticket();
         $is_escalate = $ticketgroup->getFromDBByCrit([

--- a/tests/Units/GroupEscalationTest.php
+++ b/tests/Units/GroupEscalationTest.php
@@ -30,6 +30,7 @@
 
 namespace GlpiPlugin\Escalade\Tests\Units;
 
+use Group;
 use CommonITILActor;
 use Glpi\DBAL\QueryExpression;
 use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
@@ -37,7 +38,6 @@ use Group_Ticket;
 use Notification;
 use NotificationTarget;
 use PluginEscaladeHistory;
-use PluginEscaladeTicket;
 use PluginEscaladeNotification;
 use QueuedNotification;
 use Ticket;
@@ -47,7 +47,7 @@ use User;
 final class GroupEscalationTest extends EscaladeTestCase
 {
     /**
-     * Standard GLPI group assignment must not remove previously assigned groups.
+     * Standard GLPI group assignment must remove previously assigned groups.
      */
     public function testStandardGroupAssignmentKeepsExistingGroups(): void
     {
@@ -66,11 +66,16 @@ final class GroupEscalationTest extends EscaladeTestCase
                 'assign' => [
                     [
                         'items_id' => $group1->getID(),
-                        'itemtype' => 'Group',
+                        'itemtype' => Group::class,
                     ],
                 ],
             ],
         ]);
+
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
+            'tickets_id' => $ticket->getID(),
+            'type' => CommonITILActor::ASSIGN,
+        ]));
 
         // Simulate adding another group from the standard GLPI actors field.
         $this->createItem(Group_Ticket::class, [
@@ -79,12 +84,12 @@ final class GroupEscalationTest extends EscaladeTestCase
             'type' => CommonITILActor::ASSIGN,
         ]);
 
-        $this->assertEquals(2, countElementsInTable(Group_Ticket::getTable(), [
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'type' => CommonITILActor::ASSIGN,
         ]));
 
-        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
+        $this->assertEquals(0, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'groups_id' => $group1->getID(),
             'type' => CommonITILActor::ASSIGN,
@@ -238,29 +243,18 @@ final class GroupEscalationTest extends EscaladeTestCase
 
         $group_ticket = new Group_Ticket();
 
-        $this->assertEquals(3, countElementsInTable(Group_Ticket::getTable(), [
+        $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [
             'tickets_id' => $ticket->getID(),
             'type' => CommonITILActor::ASSIGN,
         ]));
 
         // Simulate the real Escalade button.
-        $_SESSION['plugin_escalade']['is_escalation'] = true;
-        $_POST['comment'] = 'Regression test escalation';
-
-        try {
-            PluginEscaladeTicket::timelineClimbAction(
-                $group4->getID(),
-                $ticket->getID(),
-                [
-                    'ticket_details' => [
-                        'id' => $ticket->getID(),
-                    ],
-                ],
-            );
-        } finally {
-            unset($_SESSION['plugin_escalade']['is_escalation']);
-            unset($_POST['comment']);
-        }
+        $this->escalateWithTimelineButton($ticket, $group4, [
+            'ticket_details' => [
+                'id' => $ticket->getID(),
+            ],
+            'comment' => 'Regression test escalation',
+        ]);
 
         // Only the destination group must remain assigned.
         $this->assertEquals(1, countElementsInTable(Group_Ticket::getTable(), [

--- a/tests/Units/TicketTest.php
+++ b/tests/Units/TicketTest.php
@@ -355,14 +355,14 @@ final class TicketTest extends EscaladeTestCase
             ],
         ]);
 
-        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id, 'type' => CommonITILActor::ASSIGN])));
 
         $this->updateItem('Ticket', $ticket_id, [
             'status' => CommonITILObject::WAITING,
         ]);
 
-        $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
+        $this->assertEquals(0, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group1_id, 'type' => CommonITILActor::ASSIGN])));
         $this->assertEquals(1, count($group_ticket->find(['tickets_id' => $ticket_id, 'groups_id' => $group2_id, 'type' => CommonITILActor::ASSIGN])));
     }
 


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !46153,  !46232
- When a user used the “Actors” field in a ticket to escalate to a group, the escalation did not take place

## Screenshots (if appropriate):
