### PR TITLE
Fix: update the escalated ticket, not the submitted one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix group escalation when using actor fields
+- Fix the escalation form updating the ticket referenced by the submitted form data instead of the escalated ticket
+- Fix the escalation form applying the submitted ticket fields for users who are not allowed to update the ticket
 
 ## [2.10.7] - 2026-08-31
 

--- a/front/ticket.form.php
+++ b/front/ticket.form.php
@@ -45,6 +45,10 @@ if (isset($_POST['escalate'])) {
         throw new AccessDeniedHttpException();
     }
 
+    // The submitted form details are only applied when the user may update the ticket itself
+    if (!$ticket->canUpdateItem()) {
+        unset($_POST['ticket_details']);
+    }
 
     PluginEscaladeTicket::timelineClimbAction($group_id, $tickets_id, $_POST);
 

--- a/inc/ticket.class.php
+++ b/inc/ticket.class.php
@@ -1371,15 +1371,19 @@ class PluginEscaladeTicket
                 $_form_object['status'] = $_SESSION['glpi_plugins']['escalade']['config']['ticket_last_status'];
             }
 
+            // The updated ticket must be the authorized one, never the one named by the submitted details
+            unset($options['ticket_details']['id']);
+
             $updates_ticket = new Ticket();
             $updates_ticket->update(
-                $options['ticket_details'] + [
+                [
+                    'id' => $tickets_id,
                     '_actors' => PluginEscaladeTicket::getTicketFieldsWithActors($tickets_id, $group_id),
-                    '_plugin_escalade_no_history' => true, // Prevent a duplicated task to be added
+                    '_plugin_escalade_no_history' => true,
                     'actortype' => CommonITILActor::ASSIGN,
                     'groups_id' => $group_id,
                     '_form_object' => $_form_object,
-                ],
+                ] + $options['ticket_details'],
             );
         }
     }

--- a/tests/Units/EscalationAccessTest.php
+++ b/tests/Units/EscalationAccessTest.php
@@ -30,7 +30,10 @@
 
 namespace GlpiPlugin\Escalade\Tests\Units;
 
+use CommonITILActor;
 use GlpiPlugin\Escalade\Tests\EscaladeTestCase;
+use Group_Ticket;
+use PluginEscaladeTicket;
 use ProfileRight;
 use Ticket;
 
@@ -63,6 +66,55 @@ final class EscalationAccessTest extends EscaladeTestCase
         $this->assertTrue(
             $ticket->canAssign() && $ticket->checkEntity(),
             'A user with only the ASSIGN right must be allowed to reach escalation routes',
+        );
+    }
+
+    public function testSubmittedTicketDetailsCannotRetargetAnotherTicket(): void
+    {
+        $this->initConfig();
+        $escalated_ticket = $this->createItem(Ticket::class, ['name' => 'Escalated ticket', 'content' => '']);
+        $other_ticket = $this->createItem(Ticket::class, ['name' => 'Other ticket', 'content' => '']);
+        $group = $this->createGroup('RetargetTestGroup');
+
+        $_POST['comment'] = 'Escalation comment';
+        PluginEscaladeTicket::timelineClimbAction(
+            $group->getID(),
+            $escalated_ticket->getID(),
+            [
+                'ticket_details' => [
+                    'id'   => $other_ticket->getID(),
+                    'name' => 'Renamed by the submitted details',
+                ],
+            ],
+        );
+
+        $this->assertEquals('Other ticket', $this->loadTicket($other_ticket->getID())->fields['name']);
+        $this->assertEquals(
+            'Renamed by the submitted details',
+            $this->loadTicket($escalated_ticket->getID())->fields['name'],
+        );
+
+        $group_ticket = new Group_Ticket();
+        $this->assertTrue($group_ticket->getFromDBByCrit([
+            'tickets_id' => $escalated_ticket->getID(),
+            'groups_id'  => $group->getID(),
+            'type'       => CommonITILActor::ASSIGN,
+        ]));
+
+        unset($_POST['comment']);
+    }
+
+    public function testAssignOnlyUserCannotApplySubmittedTicketDetails(): void
+    {
+        $this->initConfig();
+        $tickets_id = $this->createItem(Ticket::class, ['name' => 'Escalation access test', 'content' => ''])->getID();
+
+        $this->setTechnicianTicketRight(Ticket::ASSIGN);
+        $this->login('tech', 'tech');
+
+        $this->assertFalse(
+            $this->loadTicket($tickets_id)->canUpdateItem(),
+            'A user with only the ASSIGN right must not have the submitted details applied to the ticket',
         );
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [ ] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

When escalating a ticket from the timeline, the form data posted by the browser was merged over the escalation payload and could carry its own ticket identifier.
That identifier took priority, so the update was applied to the ticket named by the posted data rather than to the ticket being escalated.
The escalation now always updates the ticket it was started on, and a regression test covers the case.

## Screenshots (if appropriate):
